### PR TITLE
add tls parameter for mqtt broker

### DIFF
--- a/default.ini
+++ b/default.ini
@@ -41,6 +41,7 @@ User = user
 Password = password
 Host = host
 Port = 1883
+tls = no
 Keepalive = 60
 ; Topic to listen on, when any message is received, the current state of all
 ; are published to their respective topics.


### PR DESCRIPTION
in my configuration service won't start if tls is not set