### PR TITLE
Typo fixed

### DIFF
--- a/sensorReporter.py
+++ b/sensorReporter.py
@@ -59,7 +59,7 @@ def on_message(client, userdata, msg):
                 s.checkState()
                 s.publishState()
     except:
-        logger.info("Unexpected error:", sys.exec_info()[0])
+        logger.info("Unexpected error:", sys.exc_info()[0])
 
 def main():
     """Polls the sensor pins and publishes any changes"""


### PR DESCRIPTION
The typo in this change leads to this error when an exception occurs:

```sudo ./sensorReporter.py sensorReporter.ini
Starting...
Loading sensorReporter.ini
Configuring logger: file = /var/log/sensorReporter.log size = 67108864 num = 10
sensors/getUpdate
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/local/lib/python2.7/dist-packages/paho/mqtt/client.py", line 2580, in _thread_main
    self.loop_forever(retry_first_connection=True)
  File "/usr/local/lib/python2.7/dist-packages/paho/mqtt/client.py", line 1378, in loop_forever
    rc = self.loop(timeout, max_packets)
  File "/usr/local/lib/python2.7/dist-packages/paho/mqtt/client.py", line 897, in loop
    rc = self.loop_read(max_packets)
  File "/usr/local/lib/python2.7/dist-packages/paho/mqtt/client.py", line 1177, in loop_read
    rc = self._packet_read()
  File "/usr/local/lib/python2.7/dist-packages/paho/mqtt/client.py", line 1766, in _packet_read
    rc = self._packet_handle()
  File "/usr/local/lib/python2.7/dist-packages/paho/mqtt/client.py", line 2239, in _packet_handle
    return self._handle_publish()
  File "/usr/local/lib/python2.7/dist-packages/paho/mqtt/client.py", line 2414, in _handle_publish
    self._handle_on_message(message)
  File "/usr/local/lib/python2.7/dist-packages/paho/mqtt/client.py", line 2574, in _handle_on_message
    self.on_message(self, self._userdata, message)
  File "./sensorReporter.py", line 63, in on_message
    logger.info("Unexpected error:", sys.exec_info()[0])
AttributeError: 'module' object has no attribute 'exec_info'
```