### PR TITLE
rpi.gpio improvments

### DIFF
--- a/gpio/dht_sensor.py
+++ b/gpio/dht_sensor.py
@@ -94,7 +94,7 @@ class DhtSensor(Sensor):
             self.temp_unit = "C"
 
         try:
-            self.smoothing = strtobool(params("Smoothing"))
+            self.smoothing = bool(strtobool(params("Smoothing")))
         except NoOptionError:
             self.smoothing = False
 

--- a/gpio/dht_sensor.py
+++ b/gpio/dht_sensor.py
@@ -18,6 +18,7 @@ from configparser import NoOptionError
 import board
 import adafruit_dht
 from core.sensor import Sensor
+from distutils.util import strtobool
 
 class DhtSensor(Sensor):
     """A polling sensor that reads and reports temperature and humidity. It

--- a/gpio/dht_sensor.py
+++ b/gpio/dht_sensor.py
@@ -93,7 +93,7 @@ class DhtSensor(Sensor):
             self.temp_unit = "C"
 
         try:
-            self.smoothing = bool(params("Smoothing"))
+            self.smoothing = strtobool(params("Smoothing"))
         except NoOptionError:
             self.smoothing = False
 

--- a/gpio/rpi_gpio.py
+++ b/gpio/rpi_gpio.py
@@ -148,7 +148,7 @@ class RpiGpioActuator(Actuator):
         GPIO.output(self.pin, self.init_state)
         
         try:
-            self.toggle = strtobool(params("Toggle"))
+            self.toggle = bool(strtobool(params("Toggle")))
         except NoOptionError:
             self.toggle = False
 
@@ -164,10 +164,12 @@ class RpiGpioActuator(Actuator):
 
         # Toggle on then off.
         if self.toggle:
-            self.log.info("Toggling pin %s %s to %s", self.pin, self.highlow_to_str(self.init_state), self.highlow_to_str(not self.init_state))
+            self.log.info("Toggling pin %s %s to %s",
+                          self.pin, self.highlow_to_str(self.init_state), self.highlow_to_str(not self.init_state))
             GPIO.output(self.pin, int(not self.init_state))
             sleep(.5)
-            self.log.info("Toggling pin %s %s to %s", self.pin, self.highlow_to_str(not self.init_state), self.highlow_to_str(self.init_state))
+            self.log.info("Toggling pin %s %s to %s",
+                          self.pin, self.highlow_to_str(not self.init_state), self.highlow_to_str(self.init_state))
             GPIO.output(self.pin, self.init_state)
 
         # Turn ON/OFF based on the message.
@@ -187,6 +189,12 @@ class RpiGpioActuator(Actuator):
     
     @staticmethod            
     def highlow_to_str(output):
+        """Converts (GPIO.)HIGH (=1) and LOW (=0) to the corresponding string
+        
+        Parameter: - "output": the GPIO constant (HIGH or LOW)
+        
+        Returns string HIGH/LOW
+        """
         if output:
             return "HIGH"
         else:

--- a/gpio/rpi_gpio.py
+++ b/gpio/rpi_gpio.py
@@ -143,7 +143,6 @@ class RpiGpioActuator(Actuator):
         out = GPIO.LOW
         try:
             self.init_state = GPIO.HIGH if params("InitialState") == "ON" else GPIO.LOW
-            # out = GPIO.HIGH if params("InitialState") == "ON" else GPIO.LOW
         except NoOptionError:
             pass
         GPIO.output(self.pin, self.init_state)

--- a/gpio/rpi_gpio.py
+++ b/gpio/rpi_gpio.py
@@ -23,6 +23,7 @@ import RPi.GPIO as GPIO
 from core.sensor import Sensor
 from core.actuator import Actuator
 from core.utils import parse_values
+from distutils.utils import strtobool 
 
 # Set to use BCM numbering.
 GPIO.setmode(GPIO.BCM)
@@ -145,8 +146,11 @@ class RpiGpioActuator(Actuator):
         except NoOptionError:
             pass
         GPIO.output(self.pin, out)
-
-        self.toggle = bool(params("Toggle"))
+        
+        try:
+            self.toggle = strtobool(params("Toggle"))
+        except NoOptionError:
+            self.toggle = False
 
         self.log.info("Configued RpoGpuiActuator: pin %d on destination %s with "
                       "toggle %s", self.pin, self.cmd_src, self.toggle)

--- a/gpio/rpi_gpio.py
+++ b/gpio/rpi_gpio.py
@@ -23,7 +23,7 @@ import RPi.GPIO as GPIO
 from core.sensor import Sensor
 from core.actuator import Actuator
 from core.utils import parse_values
-from distutils.utils import strtobool 
+from distutils.util import strtobool 
 
 # Set to use BCM numbering.
 GPIO.setmode(GPIO.BCM)
@@ -165,10 +165,10 @@ class RpiGpioActuator(Actuator):
 
         # Toggle on then off.
         if self.toggle:
-            self.log.info("Toggling pin %s HIGH to LOW", self.pin)
-            GPIO.output(self.pin, not self.init_state)
+            self.log.info("Toggling pin %s %s to %s", self.pin, self.highlow_to_str(self.init_state), self.highlow_to_str(not self.init_state))
+            GPIO.output(self.pin, int(not self.init_state))
             sleep(.5)
-            self.log.info("Toggling pin %s LOW to HIGH", self.pin)
+            self.log.info("Toggling pin %s %s to %s", self.pin, self.highlow_to_str(not self.init_state), self.highlow_to_str(self.init_state))
             GPIO.output(self.pin, self.init_state)
 
         # Turn ON/OFF based on the message.
@@ -185,3 +185,10 @@ class RpiGpioActuator(Actuator):
                 self.log.info("Setting pin %d to %s", self.pin,
                               "HIGH" if out == GPIO.HIGH else "LOW")
                 GPIO.output(self.pin, out)
+    
+    @staticmethod            
+    def highlow_to_str(output):
+        if output:
+            return "HIGH"
+        else:
+            return "LOW"

--- a/gpio/rpi_gpio.py
+++ b/gpio/rpi_gpio.py
@@ -142,10 +142,11 @@ class RpiGpioActuator(Actuator):
 
         out = GPIO.LOW
         try:
-            out = GPIO.HIGH if params("InitialState") == "ON" else GPIO.LOW
+            self.init_state = GPIO.HIGH if params("InitialState") == "ON" else GPIO.LOW
+            # out = GPIO.HIGH if params("InitialState") == "ON" else GPIO.LOW
         except NoOptionError:
             pass
-        GPIO.output(self.pin, out)
+        GPIO.output(self.pin, self.init_state)
         
         try:
             self.toggle = strtobool(params("Toggle"))
@@ -165,10 +166,10 @@ class RpiGpioActuator(Actuator):
         # Toggle on then off.
         if self.toggle:
             self.log.info("Toggling pin %s HIGH to LOW", self.pin)
-            GPIO.output(self.pin, GPIO.LOW)
+            GPIO.output(self.pin, not self.init_state)
             sleep(.5)
             self.log.info("Toggling pin %s LOW to HIGH", self.pin)
-            GPIO.output(self.pin, GPIO.HIGH)
+            GPIO.output(self.pin, self.init_state)
 
         # Turn ON/OFF based on the message.
         else:


### PR DESCRIPTION
- fixed bool parsing from the config file (any bool-ish value is now supported)
- fixed "Toggle" paramter to be optional (default value = false)
- changed toggle function to recognize the initial state (initial state = ON: toggle high -> low & low -> high; OFF: low -> high & high -> low

tested the changes on RPi4b with openHAB 3.1
fixes issue #72 