### PR TITLE
OpenHAB API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Level = INFO
 ```
 `Syslog` can be any boolean value.
 When true no other parameters are required.
-`Level` is the default logging level for the core parts of sensor_reporter and any plug-in that doesn't define it's own `Level` parameter.
+`Level` is the default logging level for the core parts of sensor_reporter and any plug-in that doesn't define it's own `Level` parameter. Allowed values: `DEBUG, INFO, WARNING, ERROR`
 
 ## Log File Example
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ However, to do anything useful, there should be at least one Connection and at l
 All logging will be published to standard out.
 In addition logging will be published to syslog or to a log file.
 
-*Security advice:* make sure your sensor_reporter.ini is owned by the user `sensorReporter` and only that user has read write permissions.
+*Security advice:* make sure your sensor_reporter.ini is owned by the user `sensorReporter` and only that user has read and write permissions.
 
-`sudo chown sensorReporter:sensorReporter sensor_reporter.ini`
+`sudo chown sensorReporter:sensorReporter sensor_reporter.ini`  
 `sudo chmod 600 sensor_reporter.ini`
 
 ## Syslog Example

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ However, to do anything useful, there should be at least one Connection and at l
 All logging will be published to standard out.
 In addition logging will be published to syslog or to a log file.
 
+*Security advice:* make sure your sensor_reporter.ini is owned by the user `sensorReporter` and only that user has read write permissions.
+
+`sudo chown sensorReporter:sensorReporter sensor_reporter.ini`
+`sudo chmod 600 sensor_reporter.ini`
+
 ## Syslog Example
 
 ```ini

--- a/exec/README.md
+++ b/exec/README.md
@@ -21,8 +21,8 @@ Parameter | Required | Restrictions | Purpose
 `Connection` | X | Comma separated list of Connections | Where the ON/OFF messages are published.
 `Level` | | DEBUG, INFO, WARNING, ERROR | When provided, sets the logging level for the actuator.
 `Command` | X | `;` and `#` are not allowed. | A valid command line command.
-`CommandSrc` | X | The Communicator destination to listen to for incoming commands.
-`ResultsDest` | X | The Communicator destination to publsih the output of the command.
+`CommandSrc` | X | The Communicator destination/openHAB string item to listen to for incoming commands.
+`ResultsDest` | X | The Communicator destination/openHAB string item to publsih the output of the command.
 `Timeout` | X | The maximum number of seconds to wait for the command to finish.
 
 When the command returns an error, `ERROR` is publsihed.

--- a/exec/README.md
+++ b/exec/README.md
@@ -21,8 +21,8 @@ Parameter | Required | Restrictions | Purpose
 `Connection` | X | Comma separated list of Connections | Where the ON/OFF messages are published.
 `Level` | | DEBUG, INFO, WARNING, ERROR | When provided, sets the logging level for the actuator.
 `Command` | X | `;` and `#` are not allowed. | A valid command line command.
-`CommandSrc` | X | The Communicator destination/openHAB string item to listen to for incoming commands.
-`ResultsDest` | X | The Communicator destination/openHAB string item to publsih the output/stdout of the command.
+`CommandSrc` | X | The Communicator destination/openHAB string/switch/integer item to listen to for incoming commands.
+`ResultsDest` | X | The Communicator destination/openHAB string item to publish the output/stdout of the command.
 `Timeout` | X | The maximum number of seconds to wait for the command to finish.
 
 When the command returns an error, `ERROR` is published.

--- a/exec/README.md
+++ b/exec/README.md
@@ -22,10 +22,10 @@ Parameter | Required | Restrictions | Purpose
 `Level` | | DEBUG, INFO, WARNING, ERROR | When provided, sets the logging level for the actuator.
 `Command` | X | `;` and `#` are not allowed. | A valid command line command.
 `CommandSrc` | X | The Communicator destination/openHAB string item to listen to for incoming commands.
-`ResultsDest` | X | The Communicator destination/openHAB string item to publsih the output of the command.
+`ResultsDest` | X | The Communicator destination/openHAB string item to publsih the output/stdout of the command.
 `Timeout` | X | The maximum number of seconds to wait for the command to finish.
 
-When the command returns an error, `ERROR` is publsihed.
+When the command returns an error, `ERROR` is published.
 
 ### Example Config
 

--- a/gpio/README.md
+++ b/gpio/README.md
@@ -81,7 +81,7 @@ Parameter | Required | Restrictions | Purpose
 `Poll` |  | Positive number | How often to call the command. When not present the sensor will watch the pin in the background and report as it starts to change state.
 `PUD` | | The Pull UP/DOWN for the pin | Defaults to "DOWN"
 `EventDetection` | | RISING, FALLING, or BOTH | When present, Poll is ignored. Indicates which GPIO event to listen for in the background.
-`Destination` | X | | Location to publish the pin state as ON/OFF.
+`Destination` | X | | Location/openHAB string item to publish the pin state as OPEN/CLOSED.
 
 ### Example Config
 
@@ -103,16 +103,16 @@ Connection = openHAB
 Pin = 17
 PUD = UP
 EventDetection = BOTH
-Destination = back-door
+Destination = back_door
 Level = DEBUG
 
 [Sensor2]
 Class = gpio.rpi_gpio.RpiGpioSensor
 Connection = openHAB
 Poll = 1
-Pin = 17
+Pin = 18
 PUD = UP
-Destination = back-door
+Destination = back_door
 Level = DEBUG
 ```
 
@@ -137,10 +137,10 @@ Parameter | Required | Restrictions | Purpose
 `Class` | X | `btle_sensor.exec_actuator.ExecSensor` |
 `Connection` | X | Comma separated list of Connections | Where the ON/OFF messages are published.
 `Level` | | DEBUG, INFO, WARNING, ERROR | When provided, sets the logging level for the sensor.
-`CommandSrc` | X | | Destination where commands are received, expects ON/OFF. If Toggle is set all messages trigger a toggle.
+`CommandSrc` | X | | Destination/openHAB switch item where commands are received, expects ON/OFF. If Toggle is set all messages trigger a toggle.
 `Pin` | X | GPIO Pin in BCM numbering
 `InitialState` | | ON or OFF | Optional, when set to ON the pin's state is initialized to HIGH.
-`Toggle` | | Boolean | When `True` simulates a button press by setting the pin to HIGH for half a second and then back to LOW.
+`Toggle` | | Boolean | When `True` simulates a button press by setting the pin to HIGH for half a second and then back to LOW. In case of `InitalState` ON it will toggle the other way around.
 
 ### Example Config
 
@@ -160,7 +160,7 @@ Level = INFO
 Class = gpio.rpi_gpio.RpiGpioActuator
 Connection = openHAB
 CommandSrc = GarageDoorCmd
-Pin = 17
+Pin = 19
 InitialState = ON
 Toggle = True
 Level = DEBUG

--- a/heartbeat/README.md
+++ b/heartbeat/README.md
@@ -16,7 +16,7 @@ Parameter | Required | Restrictions | Purpose
 `Level` | | DEBUG, INFO, WARNING, ERROR | When provided, sets the logging level for the sensor.
 `Poll` | X | Positive number in seconds | How often to publish the uptime.
 `Num-Dest` | X | | Destination/openHAB number item to publish the uptime in milliseconds.
-`Str-Dest` | X | | Destinationt/openHAB string item to pubnlish dd:hh:mm:ss.
+`Str-Dest` | X | | Destinationt/openHAB string item to publish dd:hh:mm:ss.
 
 ## Example Config
 

--- a/heartbeat/README.md
+++ b/heartbeat/README.md
@@ -15,8 +15,8 @@ Parameter | Required | Restrictions | Purpose
 `Connection` | X | Comma separated list of Connections | Where the ON/OFF messages are published.
 `Level` | | DEBUG, INFO, WARNING, ERROR | When provided, sets the logging level for the sensor.
 `Poll` | X | Positive number in seconds | How often to publish the uptime.
-`Num-Dest` | X | | Destination to publish the uptime in milliseconds.
-`Str-Dest` | X | | Destinationt to pubnlish dd:hh:mm:ss.
+`Num-Dest` | X | | Destination/openHAB number item to publish the uptime in milliseconds.
+`Str-Dest` | X | | Destinationt/openHAB string item to pubnlish dd:hh:mm:ss.
 
 ## Example Config
 
@@ -36,7 +36,7 @@ Level = INFO
 Class = heartbeat.heartbeat.Heartbeat
 Connection = openHAB
 Poll = 60
-Num-Dest = heartbeat/num
-Str-Dest = heartbeat/str
+Num-Dest = heartbeat_num
+Str-Dest = heartbeat_str
 Level = INFO
 ```

--- a/network/README.md
+++ b/network/README.md
@@ -46,7 +46,7 @@ Class = network.arp_sensor.ArpSensor
 Poll = 10
 Connection = openHAB
 MAC = aa:bb:cc:dd:ee:ff
-Destination = my-phone
+Destination = my_phone
 Level = DEBUG
 ```
 

--- a/openhab_rest/README.md
+++ b/openhab_rest/README.md
@@ -23,6 +23,8 @@ Parameter | Required | Restrictions | Purpose
 `Name` | X | | Unique to sensor_reporter | Name for the connection, used in the list of Connections for Actuators and Sensors.
 `URL` | X | http URL | The base URL and port of the openHAB instance.
 `RefreshItem` | X | | Name of a Switch Item; sending an ON command to the Item will cause sensor_reporter to publish the most recent state of all the sensors.
+`openHAB-Version` | | float | Version of the OpenHAB installation to connect to as floating point figure. Default is '2.0'.
+`API-Token` | | | The API token generated on the [web interface](https://www.openhab.org/docs/configuration/apitokens.html). Only needed if 'settings > API-security > implicit user role (advanced settings)' is disabled. If no API token is specified sensor_reporter tries to connect without authentication
 
 ## Example Configs
 
@@ -36,6 +38,8 @@ Class = openhab_rest.rest_conn.OpenhabREST
 Name = openHAB
 URL = http://localhost:8080
 RefreshItem = Test_Refresh
+openHAB-Version = 3.1
+API-Token = <API-Token generated from openHAB profil page>
 Level = INFO
 
 [Sensor1]
@@ -51,4 +55,4 @@ To detect when a sensor_reporter goes offline, use the Heartbeat and a timer in 
 
 
 ## OpenHAB Setup
-Login in openHAB as Admin and add an new item for every sensor/actor to use with sensor_reporter. Obviously the item names in openHAB and in the sensor_reporter config have to be the identical. Item lable can be chosen freely. The item type vary, see the plugin readme's for more information.
+Login in openHAB as Admin and add an new point (settings > model > add point) for every sensor/actor to use with sensor_reporter. You can add the point straight away to the [semantic model](https://www.openhab.org/docs/tutorial/model.html) of your smart home or do it later. Obviously the point names in openHAB and in the sensor_reporter config have to be the identical. Point lable can be chosen freely. The point type vary, see the plugin readme's for more information.

--- a/openhab_rest/README.md
+++ b/openhab_rest/README.md
@@ -23,8 +23,8 @@ Parameter | Required | Restrictions | Purpose
 `Name` | X | | Unique to sensor_reporter | Name for the connection, used in the list of Connections for Actuators and Sensors.
 `URL` | X | http URL | The base URL and port of the openHAB instance.
 `RefreshItem` | X | | Name of a Switch Item; sending an ON command to the Item will cause sensor_reporter to publish the most recent state of all the sensors.
-`openHAB-Version` | | float | Version of the OpenHAB installation to connect to as floating point figure. Default is '2.0'.
-`API-Token` | | | The API token generated on the [web interface](https://www.openhab.org/docs/configuration/apitokens.html). Only needed if 'settings > API-security > implicit user role (advanced settings)' is disabled. If no API token is specified sensor_reporter tries to connect without authentication
+`openHAB-Version` | | float | Version of the OpenHAB server to connect to as floating point figure. Default is '2.0'.
+`API-Token` | | | The API token generated on the [web interface](https://www.openhab.org/docs/configuration/apitokens.html). Only needed if 'settings > API-security > implicit user role (advanced settings)' is disabled. If no API token is specified sensor_reporter tries to connect without authentication.
 
 ## Example Configs
 
@@ -55,4 +55,4 @@ To detect when a sensor_reporter goes offline, use the Heartbeat and a timer in 
 
 
 ## OpenHAB Setup
-Login in openHAB as Admin and add an new point (settings > model > add point) for every sensor/actor to use with sensor_reporter. You can add the point straight away to the [semantic model](https://www.openhab.org/docs/tutorial/model.html) of your smart home or do it later. Obviously the point names in openHAB and in the sensor_reporter config have to be the identical. Point lable can be chosen freely. The point type vary, see the plugin readme's for more information.
+Login in openHAB as Admin and add a new point (settings > model > add point) for every sensor/actor to use with sensor_reporter. You can add the point straight away to the [semantic model](https://www.openhab.org/docs/tutorial/model.html) of your smart home or do it later. Obviously the point names in openHAB and in the sensor_reporter config have to be the identical. Point lable can be chosen freely. The point type vary, see the plugin readme's for more information.

--- a/openhab_rest/README.md
+++ b/openhab_rest/README.md
@@ -55,4 +55,8 @@ To detect when a sensor_reporter goes offline, use the Heartbeat and a timer in 
 
 
 ## OpenHAB Setup
-Login in openHAB as Admin and add a new point (settings > model > add point) for every sensor/actor to use with sensor_reporter. You can add the point straight away to the [semantic model](https://www.openhab.org/docs/tutorial/model.html) of your smart home or do it later. Obviously the point names in openHAB and in the sensor_reporter config have to be the identical. Point lable can be chosen freely. The point type vary, see the plugin readme's for more information.
+Login in openHAB as Admin and add a new point (settings > model > add point) for every sensor/actor to use with sensor_reporter.
+You can add the point straight away to the [semantic model](https://www.openhab.org/docs/tutorial/model.html) of your smart home or do it later.
+Obviously the point names in openHAB and in the sensor_reporter config have to be the identical.
+Point lable can be chosen freely.
+The point type vary, see the plugin readme's for more information.

--- a/openhab_rest/README.md
+++ b/openhab_rest/README.md
@@ -42,9 +42,13 @@ Level = INFO
 Class = heartbeat.heartbeat.Heartbeat
 Connection = openHAB
 Poll = 60
-Num-Dest = heartbeat/num
-Str-Dest = heartbeat/str
+Num-Dest = heartbeat_num
+Str-Dest = heartbeat_str
 Level = INFO
 ```
 
 To detect when a sensor_reporter goes offline, use the Heartbeat and a timer in openHAB to detect when the heartbeat stops.
+
+
+## OpenHAB Setup
+Login in openHAB as Admin and add an new item for every sensor/actor to use with sensor_reporter. Obviously the item names in openHAB and in the sensor_reporter config have to be the identical. Item lable can be chosen freely. The item type vary, see the plugin readme's for more information.

--- a/openhab_rest/rest_conn.py
+++ b/openhab_rest/rest_conn.py
@@ -56,9 +56,11 @@ class OpenhabREST(Connection):
             try:
                 self.api_token = params("API-Token")
             except NoOptionError:
-                self.log.info("No API-Token specified, openHAB authentication disabled")
                 self.api_token = ""
-
+                
+            if not bool(self.api_token):
+                self.log.info("No API-Token specified, connecting to openHAB without authentication")
+                
         # Subscribe to SSE events and start processing the events
         # if API-Token is provided and supported then include it in the request
         if self.OH_version >= 3.0 and bool(self.api_token):


### PR DESCRIPTION
added support for openHAB 3.0 REST API (via param openHAB-Version)
added support for optional openHAB 3.0 API token authentication (via param API-Token)
updated readme with new new config parameters
added readme section to explane OH setup with sensor_reporter
updated readme config examples to work with OH3 (item names doesn't support '-' and '/')
updated readme's to make more clear what data type on the OH3 REST API back end is required

tested the rest_conn.py changes with OH3.1. I didn't tested it with OH2, but setting openHAB-Version 2.0, or removing it from the config resulted in the same HTTP error that I had with your original version.
fixes #76 