### PR TITLE
Reconnect to server

### DIFF
--- a/mqtt/mqtt_conn.py
+++ b/mqtt/mqtt_conn.py
@@ -18,7 +18,6 @@ Classes: MqttConnection
 """
 from configparser import NoOptionError
 import socket
-import ssl
 import traceback
 from time import sleep
 import paho.mqtt.client as mqtt
@@ -152,7 +151,8 @@ class MqttConnection(Connection):
         try:
             if not self.connected:
                 self.log.warning(
-                    "MQTT is not currently connected! Ignoring message")
+                    "MQTT is not currently connected!"
+                    " Ignoring message: %s, for topic: %s" , message, topic)
                 return
             full_topic = "{}/{}".format(self.root_topic, topic)
             rval = self.client.publish(
@@ -240,7 +240,7 @@ class MqttConnection(Connection):
             self.client.subscribe(reg)
 
         # causes sensors to republish their states
-        self.msg_processor("connected")
+        self.msg_processor("MQTT connected")
 
     def on_disconnect(self, client, userdata, retcode):
         """Called when the client disconnects from the broker. If the reason was
@@ -255,17 +255,10 @@ class MqttConnection(Connection):
 
         self.connected = False
         if retcode != 0:
-            codes = {
-                1: "incorrect protocol version",
-                2: "invalid client identifier",
-                3: "server unavailable",
-                4: "bad username or password",
-                5: "not authorized",
-            }
             self.log.error(
-                "Unexpected disconnect code %s: %s, reconnecting",
+                "Unexpected disconnect code %s: %s reconnecting",
                 retcode,
-                codes[retcode],
+                mqtt.error_string(retcode),
             )
             self._connect()
 

--- a/openhab_rest/README.md
+++ b/openhab_rest/README.md
@@ -53,6 +53,11 @@ Level = INFO
 
 To detect when a sensor_reporter goes offline, use the Heartbeat and a timer in openHAB to detect when the heartbeat stops.
 
+This connection has a passive disconnect detection.
+Whenever a message to openHAB is send the reception of the message is checked.
+If there is no message reception detected eg. after the restart of openHAB, sensor_reporter will automatically reconnect.
+To make full use of this feature a Heartbeat every 60s is recommended.
+
 
 ## OpenHAB Setup
 Login in openHAB as Admin and add a new point (settings > model > add point) for every sensor/actor to use with sensor_reporter.

--- a/openhab_rest/rest_conn.py
+++ b/openhab_rest/rest_conn.py
@@ -16,7 +16,7 @@
 Classes:
     - openhab_rest: publishes state updates to openHAB Items.
 """
-from threading import Thread
+from threading import Thread, Timer
 from configparser import NoOptionError
 import json
 import traceback
@@ -24,6 +24,28 @@ import requests
 import sseclient
 from core.connection import Connection
 
+def connect_oh_rest(caller):
+    """ Subscribe to SSE events and start processing the events
+        if API-Token is provided and supported then include it in the request"""
+    try:
+        if caller.openhab_version >= 3.0 and bool(caller.api_token):
+            header = {'Authorization': 'Bearer ' + caller.api_token }
+            stream = requests.get("{}/rest/events".format(caller.openhab_url),
+                                  headers=header, stream=True)
+
+        else:
+            stream = requests.get("{}/rest/events".format(caller.openhab_url),
+                                  stream=True)
+        caller.client = sseclient.SSEClient(stream)
+
+    except requests.exceptions.Timeout:
+        caller.log.error("Timed out connecting to %s", caller.openhab_url)
+    except requests.exceptions.ConnectionError as ex:
+        caller.log.error("Failed to connect to %s, response: %s", caller.openhab_url, ex)
+    except requests.exceptions.HTTPError as ex:
+        caller.log.error("Received and unsuccessful response code %s", ex)
+
+    caller.reciever = OpenhabReciever(caller)
 
 class OpenhabREST(Connection):
     """Publishes a state to a given openHAB Item. Expects there to be a URL
@@ -63,25 +85,18 @@ class OpenhabREST(Connection):
                 self.log.info("No API-Token specified,"
                 " connecting to openHAB without authentication")
 
-        # Subscribe to SSE events and start processing the events
-        # if API-Token is provided and supported then include it in the request
-        if self.openhab_version >= 3.0 and bool(self.api_token):
-            header = {'Authorization': 'Bearer ' + self.api_token }
-            stream = requests.get("{}/rest/events".format(self.openhab_url),
-                                  headers=header, stream=True)
+        self.client = None
+        self.reciever = None
+        connect_oh_rest(self)
 
-        else:
-            stream = requests.get("{}/rest/events".format(self.openhab_url),
-                                  stream=True)
-        self.client = sseclient.SSEClient(stream)
 
-        self.reciever = OpenhabReciever(self)
 
     def publish(self, message, destination, filter_echo=False):
         """Publishes the passed in message to the passed in destination as an update.
 
-        Handle filter_echo=Ture the same way as usual publishing of messages
+        Handle filter_echo=True the same way as usual publishing of messages
         since openHAB won't send an status update to all subcribers"""
+        self.reciever.start_watchdog()
         try:
             self.log.debug("Publishing message %s to %s", message, destination)
             # openHAB 2.x doesn't need the Content-Type header
@@ -100,11 +115,16 @@ class OpenhabREST(Connection):
                                     headers=header, data=message, timeout=10)
 
             response.raise_for_status()
+            self.reciever.activate_watchdog()
         except ConnectionError:
             self.log.error("Failed to connect to %s\n%s", self.openhab_url,
                            traceback.format_exc())
         except requests.exceptions.Timeout:
-            self.log.error("Timed out connecting to %s")
+            self.log.error("Timed out connecting to %s", self.openhab_url)
+        except requests.exceptions.ConnectionError as ex:
+            #handes exception "[Errno 111] Connection refused"
+            # which is not caught by above "ConnectionError"
+            self.log.error("Failed to connect to %s, response: %s", self.openhab_url, ex)
         except requests.exceptions.HTTPError as ex:
             self.log.error("Received and unsuccessful response code %s", ex)
 
@@ -121,8 +141,13 @@ class OpenhabReciever():
         self.stop_thread = False
         # copy reciever object to local class
         self.client = caller.client
-        self.thread = Thread(target=self._get_messages, args=(caller,))
-        self.thread.start()
+        self.caller = caller
+        self.watchdog = None
+        self.watchdog_activ = False
+        # in case of a connection error dont start the get_messages thread
+        if self.client:
+            self.thread = Thread(target=self._get_messages, args=(caller,))
+            self.thread.start()
 
     def _get_messages(self, caller):
         """Blocks until stop is set to True. Loops through all the events on the
@@ -130,6 +155,10 @@ class OpenhabReciever():
         Item's handler.
         """
         for event in self.client.events():
+            # reset reconnect watchdog
+            if self.watchdog:
+                self.watchdog.cancel()
+
             if self.stop_thread:
                 self.client.close()
                 caller.log.debug("Old OpenHab connection closed")
@@ -151,9 +180,32 @@ class OpenhabReciever():
                     caller.log.info("Received command from %s: %s", item, msg)
                     caller.registered[item](msg)
 
+    def _wd_timeout(self):
+        """watchdog handler: will reconnect to openhab when invoced"""
+        if self.watchdog_activ:
+            self.caller.log.info("connection EXPIRED, reconnecting")
+            self.stop()
+            connect_oh_rest(self.caller)
+
+    def start_watchdog(self):
+        """start watchdog before msg gets sent to openhabREST
+        if the watchdog gets activated and after 2s no msg from openHAB was
+        received the connection gets reseted
+        """
+        if self.watchdog:
+            self.watchdog.cancel()
+        self.watchdog_activ = False
+        self.watchdog = Timer(2, self._wd_timeout)
+        self.watchdog.start()
+
+    def activate_watchdog(self):
+        """enable watchdog after msg was succesful send (no exeption due to connection error)
+        avoids a reconnect atempt when the connection was unsuccessful
+        """
+        self.watchdog_activ = True
+
     def stop(self):
         """Sets a flag to stop the _get_messages thread and to close the openHAB connection.
         Since the thread itself blocks until a message is recieved we won't wait for it
         """
         self.stop_thread = True
-        

--- a/sensor_reporter.py
+++ b/sensor_reporter.py
@@ -56,6 +56,8 @@ def reload_configuration(signum, frame, config_file):
     global poll_mgr
     if poll_mgr:
         poll_mgr.stop()
+        #cleanup poll_mgr compleatly befor starting over
+        poll_mgr = None
         poll_mgr = create_poll_manager(config_file)
         register_sig_handlers(config_file, poll_mgr)
         poll_mgr.start()
@@ -129,7 +131,8 @@ def init_logger(config):
         stdout_handler.setFormatter(formatter)
         root_logger.addHandler(stdout_handler)
 
-    logger.info("Setting logging level to {}".format(config.get("Logging", "Level", fallback="INFO")))
+    logger.info("Setting logging level to {}"
+                .format(config.get("Logging", "Level", fallback="INFO")))
 
 def create_connection(config, section):
     """Creates a Connection using reflection based on the passed in section of
@@ -222,7 +225,8 @@ def on_message(msg):
     """
     try:
         if not poll_mgr:
-            logger.info("Received a request for current sensor states before poll_mgr has been created, ignoring.")
+            logger.info("Received a request for current sensor states"
+                        " before poll_mgr has been created, ignoring.")
             return
         if msg:
             logger.info("Message: {}".format(msg))


### PR DESCRIPTION
+added passive reconnect feature to openHAB REST (this will renew the subscription on OH if it is broken), tested on OH2 & 3
*fixed unexpected exception after MQTT connection loss on paho-mqtt v1.6.1 due to error code 7, tested on paho-mqtt v1.5.1 & v1.6.1 fixes #75
*fixed publishing of msg on expired connection after cfg reload
*removed unused import (ssl)
*small pylint fixes

As usual I tested the changes in detail.