### PR TITLE
ds18x20 consistency

### DIFF
--- a/core/actuator.py
+++ b/core/actuator.py
@@ -76,20 +76,20 @@ class Actuator(ABC):
         resources.
         """
 
-    def _publish(self, message, comm, trigger=None):
+    def _publish(self, message, comm):
         """Protected method that will publish the passed in message to the
-        passed in comm(unicators). Optionally specifie the event trigger
-        so the connection can decide where to publish.
+        passed in comm(unicators).
 
         Arguments:
-        - message: the message to publish
-        - comm: communication dictionary, with information where to publish
-                contains connection named dictionarys for each connection,
-                containing the connection related parameters
-        - trigger: optional, specifies what event triggerd the publish,
-                   defines the subdirectory in comm to look for the return topic"""
+        - message:     the message to publish
+        - comm:        communication dictionary, with information where to publish
+                       contains connection named dictionarys for each connection,
+                       containing the connection related parameters
+        """
         for conn in comm.keys():
-            self.connections[conn].publish(message, comm[conn], trigger)
+            #currently for actuators the connectors don't support the parameter output_name
+            #so we set it to None
+            self.connections[conn].publish(message, comm[conn], None)
 
     def publish_actuator_state(self):
         """Called to publish the current state of the actuator to the publishers.

--- a/core/connection.py
+++ b/core/connection.py
@@ -41,18 +41,22 @@ class Connection(ABC):
         set_log_level(conn_cfg, self.log)
 
     @abstractmethod
-    def publish(self, message, comm_conn, trigger=None):
+    def publish(self, message, comm_conn, output_name=None):
         """Abstarct method that must be overriden. When called, send the passed
         in message to the passed in comm(unication)_conn(ection) related dictionary.
-        An trigger can be specified optional so the connection knows what sensor event
-        triggered the publish.
+        An output_name can be specified optional to set a output channel to publish to.
 
         Arguments:
-        - message: the message to process / publish
-        - comm_conn: dictionary containing only the parameters for the called connection,
-                     e. g. information where to publish
-        - trigger: optional, specifies what event triggerd the publish,
-                   defines the subdirectory in comm_conn to look for the return topic
+        - message:     the message to process / publish
+        - comm_conn:   dictionary containing only the parameters for the called connection,
+                       e. g. information where to publish
+        - output_name: optional, the output channel to publish the message to,
+                       defines the subdirectory in comm_conn to look for the return topic.
+                       When defined the output_name must be present
+                       in the sensor YAML configuration:
+                       Connections:
+                           <connection_name>:
+                                <output_name>:
         """
 
     def publish_device_properties(self):

--- a/core/connection.py
+++ b/core/connection.py
@@ -42,7 +42,7 @@ class Connection(ABC):
 
     @abstractmethod
     def publish(self, message, comm_conn, output_name=None):
-        """Abstarct method that must be overriden. When called, send the passed
+        """Abstract method that must be overriden. When called, send the passed
         in message to the passed in comm(unication)_conn(ection) related dictionary.
         An output_name can be specified optional to set a output channel to publish to.
 

--- a/core/sensor.py
+++ b/core/sensor.py
@@ -75,28 +75,34 @@ class Sensor(ABC):
         implementation is a pass.
         """
 
-    def _send(self, message, comm, trigger=None):
-        """Sends message the the comm(unicators). Optionally specifie the event trigger
-        so the connection can decide where to publish.
+    def _send(self, message, comm, output_name=None):
+        """Sends message the the comm(unicators). Optionally specifie the output_name
+        to set a output channel to publish to.
 
         Arguments:
-        - message: the message to publish as string or dict (generated from get_msg_from_values)
-        - comm: communication dictionary, with information where to publish
-                contains connection named dictionarys for each connection,
-                containing the connection related parameters
-        - trigger: optional, specifies what event triggerd the publish,
-                   defines the subdirectory in comm to look for the return topic"""
+        - message:     the message to publish as string or dict (generated from get_msg_from_values)
+        - comm:        communication dictionary, with information where to publish
+                       contains connection named dictionarys for each connection,
+                       containing the connection related parameters
+        - output_name: optional, the output channel to publish the message to,
+                       defines the subdirectory in comm_conn to look for the return topic.
+                       When defined the output_name must be present
+                       in the sensor YAML configuration:
+                       Connections:
+                           <connection_name>:
+                                <output_name>:
+        """
         #accept regular messages directly
         if not isinstance(message, dict):
             msg = message
 
         for conn in comm.keys():
             #if message is a value_dict from get_msg_from_values, grab the current conn message
-            #use list in default section if conn section is not present 
+            #use list in default section if conn section is not present
             if isinstance(message, dict):
                 msg = message.get(conn, message[DEFAULT_SECTION])
 
-            self.publishers[conn].publish(msg, comm[conn], trigger)
+            self.publishers[conn].publish(msg, comm[conn], output_name)
 
     def cleanup(self):
         """Called when shutting down the sensor, give it a chance to clean up

--- a/core/utils.py
+++ b/core/utils.py
@@ -251,8 +251,9 @@ def configure_device_channel(comm:dict, *, is_output:bool,
     can register the device correctly.
 
     Call this method once for each output the sensor has once, to register all output channel.
-    Currently only actuators with one input and output are supported, so one call to
+    For actuators, only one input and output is currently supported, so one call to
     this method is sufficient.
+    After calling this method, self._register() must be called, see the example below.
 
     Parameters:
     - comm:         the connections dictionary of the device
@@ -261,7 +262,7 @@ def configure_device_channel(comm:dict, *, is_output:bool,
 
     Optional Parameters:
     - output_name:  the name used to publish messages by _send() and _publish().
-                    For sensors specifie the name of the output channel if more than one used
+                    For sensors: specifie the name of the output channel if more than one used
                     otherweise don't use this parameter.
                     For actuators: don't use this parameter
     - datatype:     the type of the data the device will publish or revieve:
@@ -279,12 +280,18 @@ def configure_device_channel(comm:dict, *, is_output:bool,
                     the homie convention named this "format"
 
     It is required to write the parameter name out, when calling this method
-    Example from the RpiGpioActuator:
-
+    ==Example from RpiGpioActuator==
     configure_device_channel(self.comm, is_output=False,
                              name="set digital output", datatype=ChanType.ENUM,
                              restrictions="ON,OFF,TOGGLE")
     self._register(self.comm, None)
+
+    ==Example 2 from heartbeat (sensor)==
+    configure_device_channel(self.comm, is_output=True, output_name=OUT_NUM,
+                                 datatype=ChanType.INTEGER, name="uptime in milliseconds")
+    configure_device_channel(self.comm, is_output=True, output_name=OUT_STRING,
+                             name="uptime in days, hours:min:sec")
+    self._register(self.comm)
     """
 
     for comm_conn in comm.values():

--- a/core/utils.py
+++ b/core/utils.py
@@ -208,44 +208,83 @@ def spread_default_parameters(config, dev_cfg):
         if key not in dev_cfg:
             dev_cfg[key] = value
 
-def verify_connections_layout(comm, log, name, triggers=None):
-    """checks if the subdictionaries in the connections section
-    are valid triggers
+def verify_connections_layout(comm, log, name, outputs=None):
+    """
+    Use this method at the end of the sensor initialisation
+    before calling configure_device_channel().
+    Checks the YAML configuration to make sure the subdictionaries
+    in the connections section are valid outputs
 
-    comm: the communications dictionary will all connections
-    log: the log instance of the device
-    name: the name of the device
-    triggers: a list of valid values for device triggers
+    comm:    the communications dictionary with all connections
+    log:     the log instance of the device
+    name:    the name of the device
+    outputs: optional, a list of valid values for device outputs.
+             If omitted, the function will ensure that the YAML
+             configuration does not specify any output channels for the device.
+             Expects the output_names used by a sensor as list e. g.:
+             outputs = [output_name1, output_name2]
     """
     for conn in comm.values():
+        #loop thru all connections
         if isinstance(conn, dict):
             for (key, value) in conn.items():
+                #loop thru sub items of the connections
+                #if sub item is a dict we found a output channel
                 if isinstance(value, dict):
-                    if not key in triggers:
-                        log.warning("%s has unknown outputs '%s' in Connections."
-                                    ' Valid outputs are: %s', name, key, triggers)
+                    if isinstance(outputs, list):
+                        if not key in outputs:
+                            log.warning("%s has unknown outputs '%s' in Connections."
+                                        ' Valid outputs are: %s', name, key, outputs)
+                    else:
+                        #handle case where outpus is not specified
+                        log.warning("%s has unexpected outputs '%s' in Connections."
+                                    ' No outputs are allowed', name, key)
 
 def configure_device_channel(comm:dict, *, is_output:bool,
                                 output_name:str = None, datatype:ChanType = ChanType.STRING,
                                 unit:str = None, name:str = None,
                                 restrictions:str = None):
-    """this method will set default values inside the connections section
-    so a connector which supports auto discover can register the device properly
+    """
+    Use this method at the end of the sensor/actuator initialisation,
+    it sets default values inside the connections section
+    so that a connector which supports auto-discover, e. g. homie_conn,
+    can register the device correctly.
+
+    Call this method once for each output the sensor has once, to register all output channel.
+    Currently only actuators with one input and output are supported, so one call to
+    this method is sufficient.
 
     Parameters:
-    - comm: the connections dictionary of the device
-    - is_output: to select if a output or a input should be configured (set to true for output)
-    - output_name: sensors may have multiple outputs, specifie the name of the output here
-    - datatype: the type of the data the device will publish or revieve:
-                [STRING, INTEGER, FLOAT, BOOLEAN, ENUM, COLOR]
-    - unit: the unit in which the sensor data is published:
-            [°C", °F, °, L, gal, V, W, A, %, m, ft, Pa, psi, #]
-    - name: the full name / description of the input/output
+    - comm:         the connections dictionary of the device
+    - is_output:    to select if a output or a input should be configured.
+                    Set to true for a sensor and false for an actuator
+
+    Optional Parameters:
+    - output_name:  the name used to publish messages by _send() and _publish().
+                    For sensors specifie the name of the output channel if more than one used
+                    otherweise don't use this parameter.
+                    For actuators: don't use this parameter
+    - datatype:     the type of the data the device will publish or revieve:
+                    [STRING, INTEGER, FLOAT, BOOLEAN, ENUM, COLOR]
+                    use class ChanType, e. g. ChanType.INTEGER
+    - unit:         the unit in which the sensor data is published:
+                    [°C, °F, °, L, gal, V, W, A, %, m, ft, Pa, psi, #]
+                    e. g. unit = "Pa"
+    - name:         the full name / description of the input/output
+                    this is visible on the connected server e. g. openHAB
     - restrictions: set allowed values for channel
                     for a numeric range e. g. -3:24
                     for possible values for datatype ENUM
                     as comma separated list e.g. 'val1,val2,val3'
                     the homie convention named this "format"
+
+    It is required to write the parameter name out, when calling this method
+    Example from the RpiGpioActuator:
+
+    configure_device_channel(self.comm, is_output=False,
+                             name="set digital output", datatype=ChanType.ENUM,
+                             restrictions="ON,OFF,TOGGLE")
+    self._register(self.comm, None)
     """
 
     for comm_conn in comm.values():

--- a/core/utils.py
+++ b/core/utils.py
@@ -236,7 +236,7 @@ def verify_connections_layout(comm, log, name, outputs=None):
                             log.warning("%s has unknown outputs '%s' in Connections."
                                         ' Valid outputs are: %s', name, key, outputs)
                     else:
-                        #handle case where outpus is not specified
+                        #handle case where outputs is not specified
                         log.warning("%s has unexpected outputs '%s' in Connections."
                                     ' No outputs are allowed', name, key)
 
@@ -250,7 +250,7 @@ def configure_device_channel(comm:dict, *, is_output:bool,
     so that a connector which supports auto-discover, e. g. homie_conn,
     can register the device correctly.
 
-    Call this method once for each output the sensor has once, to register all output channel.
+    Call this method once for each output the sensor has, to register all output channels.
     For actuators, only one input and output is currently supported, so one call to
     this method is sufficient.
     After calling this method, self._register() must be called, see the example below.
@@ -262,10 +262,10 @@ def configure_device_channel(comm:dict, *, is_output:bool,
 
     Optional Parameters:
     - output_name:  the name used to publish messages by _send() and _publish().
-                    For sensors: specifie the name of the output channel if more than one used
+                    For sensors: specify the name of the output channel if more than one is used
                     otherweise don't use this parameter.
                     For actuators: don't use this parameter
-    - datatype:     the type of the data the device will publish or revieve:
+    - datatype:     the type of the data the device will be published or received:
                     [STRING, INTEGER, FLOAT, BOOLEAN, ENUM, COLOR]
                     use class ChanType, e. g. ChanType.INTEGER
     - unit:         the unit in which the sensor data is published:

--- a/gpio/README.md
+++ b/gpio/README.md
@@ -100,13 +100,13 @@ Reboot the Raspberry Pi.
 
 | Parameter     | Required           | Restrictions                        | Purpose                                                                                                                                                     |
 |---------------|--------------------|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `Class`       | :heavy_check_mark: | `gpio.ds18x20_sensor.Ds18x20Sensor` |                                                                                                                                                             |
-| `Connections` | :heavy_check_mark: | dictionary of connectors            | Defines where to publish the sensor status for each connection.                                                                                             |
-| `Level`       | :X:                | `DEBUG`, `INFO`, `WARNING`, `ERROR` | Override the global log level and use another one for this sensor.                                                                                          |
-| `Poll`        | :heavy_check_mark: | Positive number                     | Refresh interval for the sensor in seconds.                                                                                                                 |
-| `Mac`         | :heavy_check_mark: |                                     | Full 1-Wire device address. To list all 1-Wire devices, run `ls /sys/bus/w1/devices`. To read a specific one, run `cat /sys/bus/w1/devices/<Mac>/w1_slave`. |
-| `TempUnit`    | :X:                | `F` or `C`                          | Temperature unit to use, defaults to `C`.                                                                                                                   |
-| `Smoothing`   | :X:                | Boolean                             | If `True`, publishes the average of the last five readings instead of each individual reading.                                                              |
+| `Class`       | X                  | `gpio.ds18x20_sensor.Ds18x20Sensor` |                                                                                                                                                             |
+| `Connections` | X                  | dictionary of connectors            | Defines where to publish the sensor status for each connection.                                                                                             |
+| `Level`       |                    | `DEBUG`, `INFO`, `WARNING`, `ERROR` | Override the global log level and use another one for this sensor.                                                                                          |
+| `Poll`        | X                  | Positive number                     | Refresh interval for the sensor in seconds.                                                                                                                 |
+| `Mac`         | X                  |                                     | Full 1-Wire device address. To list all 1-Wire devices, run `ls /sys/bus/w1/devices`. To read a specific one, run `cat /sys/bus/w1/devices/<Mac>/w1_slave`. |
+| `TempUnit`    |                    | `F` or `C`                          | Temperature unit to use, defaults to `C`.                                                                                                                   |
+| `Smoothing`   |                    | Boolean                             | If `True`, publishes the average of the last five readings instead of each individual reading.                                                              |
 
 ### Outputs
 
@@ -117,12 +117,13 @@ The DS18x20 sensor has only one output, the temperature.
 Publishes to a MQTT connection with name `MQTT`:
 
 ```yaml
+#Logging and connection configuration omitted
+
 SensorTempOutside:
     Class: gpio.ds18x20_sensor.Ds18x20Sensor
     Connections:
         MQTT:
-            Temperature:
-                StateDest: temp/outside
+            StateDest: temp/outside
     Poll: 10
     Mac: 28-a66c801e64ff
 ```

--- a/gpio/ds18x20_sensor.py
+++ b/gpio/ds18x20_sensor.py
@@ -78,8 +78,8 @@ class Ds18x20Sensor(Sensor):
         if self.smoothing:
             self.temp_readings = [None] * 5
 
-        #verify configured connection during init, so errors occur immediatly
-        #since no triggers are specified this sensor doesn't allows to configure output channels
+        #verify configured connections during init, so errors occur immediatly
+        #this sensor doesn't allows to configure output channels, check non is present
         verify_connections_layout(self.comm, self.log, self.name)
         self.log.info("Sensor %s created, setting parameters.", self.name)
         self.log.debug("%s will report to following connections:\n%s",

--- a/gpio/gpio_led.py
+++ b/gpio/gpio_led.py
@@ -20,7 +20,7 @@ import colorsys
 import yaml
 from RPi import GPIO
 from core.actuator import Actuator
-from core.utils import verify_connections_layout, configure_device_channel, ChanType
+from core.utils import configure_device_channel, ChanType
 from gpio.rpi_gpio import set_gpio_mode
 
 #constants
@@ -53,7 +53,7 @@ class GpioColorLED(Actuator):
             Blue: z
             White: 100
         PWM-Frequency: 100  #the frequecy for the PWM for all pin's
-        InvertOut: True     #whether to invert the output, true for common anode LED's 
+        InvertOut: True     #whether to invert the output, true for common anode LED's
         Connections:        #the connections dict
             xxx
         """
@@ -119,9 +119,6 @@ class GpioColorLED(Actuator):
                                "Make sure the pin number is correct. Error Message: %s",
                                self.name, self.pin, self.gpio_mode, err)
 
-        #verify that defined output channels in Connections section are valid
-        verify_connections_layout(self.comm, self.log, self.name)
-
         self.log.info("Configued GpioColorLED %s: pin numbering %s, and pins\n%s",
                       self.name, self.gpio_mode, self.pin)
         self.log.debug("%s LED's set to: %s and has following configured connections: \n%s",
@@ -140,7 +137,7 @@ class GpioColorLED(Actuator):
         self._register(self.comm, None)
 
     def on_message(self, msg):
-        """Called when the actuator receives a message. 
+        """Called when the actuator receives a message.
         Changes LED PWM duty cycle according to the message.
         Expects comma separated values formated as HSV color: 'h,s,v'
         """

--- a/gpio/gpio_led.py
+++ b/gpio/gpio_led.py
@@ -119,8 +119,8 @@ class GpioColorLED(Actuator):
                                "Make sure the pin number is correct. Error Message: %s",
                                self.name, self.pin, self.gpio_mode, err)
 
-        #verify that defined Triggers in Connections section are valid
-        verify_connections_layout(self.comm, self.log, self.name, [])
+        #verify that defined output channels in Connections section are valid
+        verify_connections_layout(self.comm, self.log, self.name)
 
         self.log.info("Configued GpioColorLED %s: pin numbering %s, and pins\n%s",
                       self.name, self.gpio_mode, self.pin)

--- a/gpio/rpi_gpio.py
+++ b/gpio/rpi_gpio.py
@@ -128,7 +128,7 @@ class RpiGpioSensor(Sensor):
 
         self.btn = ButtonPressCfg(dev_cfg, self)
 
-        #verify that defined Triggers in Connections section are valid!
+        #verify that defined output channels in Connections section are valid!
         verify_connections_layout(self.comm, self.log, self.name,
                                   [OUT_SWITCH, OUT_SHORT_PRESS, OUT_LONG_PRESS])
 
@@ -300,8 +300,9 @@ class RpiGpioActuator(Actuator):
             else:
                 self.current_state = self.init_state
 
-        #verify that defined Triggers in Connections section are valid
-        verify_connections_layout(self.comm, self.log, self.name, [])
+        #verify configured connections during init, so errors occur immediatly
+        #this sensor doesn't allows to configure output channels, check non is present
+        verify_connections_layout(self.comm, self.log, self.name)
 
         self.log.info("Configued RpiGpioActuator %s: pin %d (%s) on with SimulateButton %s",
                       self.name, self.pin, self.gpio_mode, self.sim_button)

--- a/gpio/rpi_gpio.py
+++ b/gpio/rpi_gpio.py
@@ -300,10 +300,6 @@ class RpiGpioActuator(Actuator):
             else:
                 self.current_state = self.init_state
 
-        #verify configured connections during init, so errors occur immediatly
-        #this sensor doesn't allows to configure output channels, check non is present
-        verify_connections_layout(self.comm, self.log, self.name)
-
         self.log.info("Configued RpiGpioActuator %s: pin %d (%s) on with SimulateButton %s",
                       self.name, self.pin, self.gpio_mode, self.sim_button)
         self.log.debug("%s has following configured connections: \n%s",

--- a/local/local_conn.py
+++ b/local/local_conn.py
@@ -95,7 +95,7 @@ class LocalConnection(Connection):
                            <connection_name>:
                                 <output_name>:
         """
-        #if output_name is in the communication dict parse it's contens
+        #if output_name is in the communication dict parse it's contents
         local_comm = comm_conn[output_name] if output_name in comm_conn else comm_conn
 
         destination = local_comm.get('StateDest')

--- a/local/local_conn.py
+++ b/local/local_conn.py
@@ -80,17 +80,23 @@ class LocalConnection(Connection):
         except KeyError:
             pass
 
-    def publish(self, message, comm_conn, trigger=None):
+    def publish(self, message, comm_conn, output_name=None):
         """Send the message or, if defined, translate the message to ON or OFF.
 
         Arguments:
-        - message: the message to process / publish
-        - comm_conn: dictionary containing only the parameters for the called connection,
-                     e. g. information where to publish
-        - trigger: optional, specifies what event triggerd the publish,
-                   defines the subdirectory in comm_conn to look for the return topic"""
-        #if trigger is in the communication dict parse it's contens
-        local_comm = comm_conn[trigger] if trigger in comm_conn else comm_conn
+        - message:     the message to process / publish
+        - comm_conn:   dictionary containing only the parameters for the called connection,
+                       e. g. information where to publish
+        - output_name: optional, the output channel to publish the message to,
+                       defines the subdirectory in comm_conn to look for the return topic.
+                       When defined the output_name must be present
+                       in the sensor YAML configuration:
+                       Connections:
+                           <connection_name>:
+                                <output_name>:
+        """
+        #if output_name is in the communication dict parse it's contens
+        local_comm = comm_conn[output_name] if output_name in comm_conn else comm_conn
 
         destination = local_comm.get('StateDest')
         if destination in self.registered:

--- a/local/local_logic.py
+++ b/local/local_logic.py
@@ -97,7 +97,7 @@ class LogicCore(Actuator):
         self.log.info("%s received %s command for logic actuator",
                       self.name, "enable" if self.enabled else "disable")
 
-    def _publish(self, message, comm, trigger=False):
+    def _publish(self, message, comm, output_name=False):
         """Protected method that will publish the passed in message to the
         passed in destination to all the passed in connections.
 
@@ -114,7 +114,7 @@ class LogicCore(Actuator):
                 msg = message.get(conn, message[DEFAULT_SECTION])
             #only publish to local connections (attrib eq)
             if hasattr(self.connections[conn], LOCAL_CONN_EQUAL_ATTRIB):
-                self.connections[conn].publish(msg, comm[conn], trigger)
+                self.connections[conn].publish(msg, comm[conn], output_name)
 
 class LogicOr (LogicCore):
     """Logical OR gate, can receive from multiple sensors

--- a/mqtt/mqtt_conn.py
+++ b/mqtt/mqtt_conn.py
@@ -124,22 +124,28 @@ class MqttConnection(Connection):
 
         self.log.info("Connection to MQTT is successful")
 
-    def publish(self, message, comm_conn, trigger=None):
+    def publish(self, message, comm_conn, output_name=None):
         """Publishes message to destination, logging if there is an error.
 
         Arguments:
-        - message: the message to process / publish
-        - comm_conn: dictionary containing only the parameters for the called connection,
-                     e. g. information where to publish
-        - trigger: optional, specifies what event triggered the publish,
-                   defines the subdirectory in comm_conn to look for the return topic"""
-        #if trigger is in the communication dict parse it's contents
-        local_comm = comm_conn[trigger] if trigger in comm_conn else comm_conn
+        - message:     the message to process / publish
+        - comm_conn:   dictionary containing only the parameters for the called connection,
+                       e. g. information where to publish
+        - output_name: optional, the output channel to publish the message to,
+                       defines the subdirectory in comm_conn to look for the return topic.
+                       When defined the output_name must be present
+                       in the sensor YAML configuration:
+                       Connections:
+                           <connection_name>:
+                                <output_name>:
+        """
+        #if output_name is in the communication dict parse it's contents
+        local_comm = comm_conn[output_name] if output_name in comm_conn else comm_conn
 
         destination = local_comm.get('StateDest')
         retain = local_comm.get('Retain', False)
 
-        #if trigger (output) is not present in comm_conn, StateDest will be None
+        #if output_name (output) is not present in comm_conn, StateDest will be None
         if destination is None:
             return
 

--- a/openhab_rest/rest_conn.py
+++ b/openhab_rest/rest_conn.py
@@ -85,22 +85,28 @@ class OpenhabREST(Connection):
         self.reciever = None
         connect_oh_rest(self)
 
-    def publish(self, message, comm_conn, trigger=None):
+    def publish(self, message, comm_conn, output_name=None):
         """Publishes the passed in message to the passed in destination as an update.
 
         Arguments:
-        - message: the message to process / publish, expected type <string>
-        - comm_conn: dictionary containing only the parameters for the called connection,
-                     e. g. information where to publish
-        - trigger: optional, specifies what event triggered the publish,
-                   defines the subdirectory in comm_conn to look for the return topic"""
+        - message:     the message to process / publish, expected type <string>
+        - comm_conn:   dictionary containing only the parameters for the called connection,
+                       e. g. information where to publish
+        - output_name: optional, the output channel to publish the message to,
+                       defines the subdirectory in comm_conn to look for the return topic.
+                       When defined the output_name must be present
+                       in the sensor YAML configuration:
+                       Connections:
+                           <connection_name>:
+                                <output_name>:
+        """
         self.reciever.start_watchdog()
 
-        #if trigger is in the communication dict parse it's contents
-        local_comm = comm_conn[trigger] if trigger in comm_conn else comm_conn
+        #if output_name is in the communication dict parse it's contents
+        local_comm = comm_conn[output_name] if output_name in comm_conn else comm_conn
         destination = local_comm.get('Item')
 
-        #if trigger (output) is not present in comm_conn, Item will be None
+        #if output_name (output) is not present in comm_conn, Item will be None
         if destination is None:
             return
 


### PR DESCRIPTION
This PR fixes #106

- changes ds18x20 sensor to be consistent with the other single output sensors
- renamed parameter for `_send()` and `_publish()` commands from 'trigger' to 'output_name' to make usage clearer. Now `_send()` , `_publish()` and '`configure_device_channel()` use the same parameter name for the same thing.
- extended the documentation and added examples to clarify usage for following methods: `_publish(), _send(), verify_connections_layout(), configure_device_channel()`
- fixed `verify_connections_layout()` 3rd parameter not being optional

I tested the changes with all connectors and the changed devices. Since I don't own a ds18x20 I could only test it partly (config gets read correctly, _send() works too)

In case there are any questions: I'll be away for a few weeks, so please be patient.