### PR TITLE
add support for 8-Relays-HAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Go into the subfolders for details in each subfolder's README.
 | [`network.dash_sensor.DashSensor`](network/README.md#networkdash_sensordashsensor)                        | Background Sensor             | Watches for Amazon Dash Button ARP packets.                                                               |
 | [`openhab_rest.rest_conn.OpenhabREST`](openhab_rest/README.md#openhab-rest-connection)                    | Connection                    | Subscribes and publishes to openHAB's REST API. Subscription is through openHAB's SSE feed.               |
 | [`roku.roku_addr.RokuAddressSensor`](roku/README.md#roku-address-sensor-deprecated)                       | Polling Sensor                | Periodically requests the addresses of all the Rokus on the subnet.                                       |
-
+| [`ic2.relay.EightRelayHAT`](i2c/README.md#i2crelayeightrelayhat)                                          | Actuator                      | Sets a relay to a given state on command. Supports 8-Relays-HAT via i2c                                   |
 
 # Architecture
 The main script is `sensor_reporter` which parses a configuration YAML file and handles operating system signal handling.

--- a/i2c/README.md
+++ b/i2c/README.md
@@ -78,9 +78,7 @@ ActuatorGarageDoor:
     Connections:
         openHAB:
             Item: GarageDoorCmd
-    Stack: 0
     Relay: 1
-    SimulateButton: True
 ```
 
 

--- a/i2c/README.md
+++ b/i2c/README.md
@@ -1,0 +1,86 @@
+# Sensors and Actuators that are controlled via i2c
+
+This module contains:
+* [i2c.relay.EightRelayHAT](#i2crelayeightrelayhat)
+
+
+
+## `i2c.relay.EightRelayHAT`
+
+Commands a [Sequent Microsystems 8-Relays-HAT](https://github.com/SequentMicrosystems/8relind-rpi) to switch a relay or if configured with SimulateButton it switches ON for half a second and then goes OFF.
+A received command will be sent back on all configured connections to the configured return topic, to keep them up to date.
+
+### Dependencies
+
+This actuator communicates via the i2c interface, therfore the GPIO 2 and 3 should be free and cannot get accessed directly e. g. with a RpiGPIOSensor.
+Also the library `lib8relay` must be installed to make this actuator work.
+
+To enable the i2c interface open the Raspberry-Pi configuration via:
+
+```bash
+sudo raspi-config
+```
+and choose Interface Options, then <b>I2C Interface</b> and yes.
+
+The user running sensor_reporter must have permission to access the i2c interface.
+To grant the `sensorReporter` user i2c permissions add the user to the group `i2c`:
+
+```bash
+sudo adduser sensorReporter i2c
+```
+
+Install `lib8relay` via:
+
+```bash
+sudo pip3 install lib8relay
+```
+
+### Parameters
+
+| Parameter        | Required | Restrictions                    | Purpose                                                                                                                                                                                                                                                                       |
+|------------------|----------|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Class`          | X        | `i2c.relay.EightRelayHAT`       |                                                                                                                                                                                                                                                                               |
+| `Connections`    | X        | dictionary of connectors        | Defines where to subscribe for messages and where to publish the status for each connection. Look at connection readme's for 'Actuator / sensor relevant parameters' for details.                                                                                             |
+| `Stack`          |          | Stack Address 0..7              | Optional, the selected stack adress which can be set via jumpers on the header 0-1-2 (no jumper: Stack =  0, default = 0, see product description [here](https://sequentmicrosystems.com/collections/industrial-automation/products/8-relays-stackable-card-for-raspberry-pi))|
+| `Relay`          | X        | Relay No. 1..8                  | The relay to control                                                                                                                                                                                                                                                          |
+| `Level`          |          | DEBUG, INFO, WARNING, ERROR     | Override the global log level and use another one for this sensor.                                                                                                                                                                                                            |
+| `ToggleDebounce` |          | decimal number                  | The interval in seconds during which repeated toggle commands are ignored (default 0.15 seconds)                                                                                                                                                                              |
+| `InitialState`   |          | ON or OFF                       | Optional, when set to ON the pin's state is initialized to HIGH. Ignores InvertOut (default OFF)                                                                                                                                                                              |
+| `SimulateButton` |          | Boolean                         | When `True` simulates a button press by setting the pin to HIGH for half a second and then back to LOW. In case of `InitalState` ON it will toggle the other way around.                                                                                                      |
+
+
+
+
+### Outputs / Inputs
+
+The EightRelayHAT has only one output and input.
+The input expects ON, OFF, TOGGLE or a datetime string as command.
+While ON, OFF set the relay accordingly, TOGGLE and a datetime string will toggle it.
+Can be connected directly to a RpiGpioSensor ShortButtonPress / LongButtonPress output.
+The output will send the relay state as ON / OFF after a change.
+When using with the openHAB connection configure a switch/string Item.
+
+### Configuration Examples
+
+```yaml
+Logging:
+    Syslog: yes
+    Level: INFO
+
+Connection1:
+    Class: openhab_rest.rest_conn.OpenhabREST
+    Name: openHAB
+    URL: http://localhost:8080
+    RefreshItem: Test_Refresh
+
+ActuatorGarageDoor:
+    Class: i2c.relay.EightRelayHAT
+    Connections:
+        openHAB:
+            Item: GarageDoorCmd
+    Stack: 0
+    Relay: 1
+    SimulateButton: True
+```
+
+

--- a/i2c/relay.py
+++ b/i2c/relay.py
@@ -22,7 +22,7 @@ import datetime
 import yaml
 import lib8relay
 from core.actuator import Actuator
-from core.utils import is_toggle_cmd, verify_connections_layout, configure_device_channel, ChanType
+from core.utils import is_toggle_cmd, configure_device_channel, ChanType
 
 def onoff_to_str(output):
     """Converts 1 to "ON" and 1 to "OFF"
@@ -89,9 +89,6 @@ class EightRelayHAT(Actuator):
             self.current_state = None
         else:
             self.current_state = self.init_state
-
-        #verify that defined Triggers in Connections section are valid
-        verify_connections_layout(self.comm, self.log, self.name, [])
 
         self.log.info("Configued EightRelayHAT %s: Stack %d, Relay %d (%s) with SimulateButton %s",
                       self.name, self.stack, self.relay,

--- a/i2c/relay.py
+++ b/i2c/relay.py
@@ -1,0 +1,187 @@
+# Copyright 2020 Richard Koshak
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contains EightRelayHAT.
+
+Classes:
+    - EightRelayHAT: switches the corresponding relay.
+"""
+from time import sleep
+from distutils.util import strtobool
+import datetime
+import yaml
+import lib8relay
+from core.actuator import Actuator
+from core.utils import is_toggle_cmd, verify_connections_layout, configure_device_channel, ChanType
+
+def onoff_to_str(output):
+    """Converts 1 to "ON" and 1 to "OFF"
+
+    Parameter: - "output": the switch constant (ON or OFF)
+
+    Returns string ON/OFF
+    """
+    if output:
+        return "ON"
+
+    return "OFF"
+
+class EightRelayHAT(Actuator):
+    """Allows switching relay on Sequent Microsystems 8-Relays-HAT. Also supports
+    toggling.
+    """
+
+    def __init__(self, connections, dev_cfg):
+        """Initializes the I2C subsystem and sets the relay to the InitialState.
+        If InitialState is not povided in params it defaults to OFF. If
+        "SimulateButton" is defined on any message will result in the relay being set to
+        ON for half a second and then back to OFF.
+
+        Parameters:
+            - "Stack": Stack Address 0..7
+            - "Relay": Relay No. 1..8
+            - "InitialState": The pin state to set when coming online, defaults
+            to "OFF", optional.
+            - "SimulateButton": Optional parameter that when set to "True" causes any
+            message received to result in setting the pin to HIGH, sleep for
+            half a second, then back to LOW.
+        """
+        super().__init__(connections, dev_cfg)
+
+        self.stack = dev_cfg.get("Stack", 0)
+
+        #relays on the HAT are scrambled up, map them correctly
+        # there is no relay 0 but array indexing starts at zero, first index is a filler
+        relay_map = [0, 1, 2, 5, 6, 7, 8, 4, 3]
+
+        self.relay = int(dev_cfg["Relay"])
+        self.mapped_relay = relay_map[self.relay]
+
+        #default state if not configured = False = off
+        self.init_state =  dev_cfg.get("InitialState", False)
+
+        try:
+            lib8relay.set(self.stack, self.mapped_relay, self.init_state)
+        except ValueError as err:
+            self.log.error("%s could not setup EightRelayHAT. "
+                           "Make sure the stack and relay "
+                           "number is correct. Error Message: %s",
+                           self.name, err)
+
+        self.sim_button = dev_cfg.get("SimulateButton", False)
+
+        #default debaunce time 0.15 seconds
+        self.toggle_debounce = float(dev_cfg.get("ToggleDebounce", 0.15))
+        self.last_toggle = datetime.datetime.fromordinal(1)
+
+        #remember the current output state
+        if self.sim_button:
+            self.current_state = None
+        else:
+            self.current_state = self.init_state
+
+        #verify that defined Triggers in Connections section are valid
+        verify_connections_layout(self.comm, self.log, self.name, [])
+
+        self.log.info("Configued EightRelayHAT %s: Stack %d, Relay %d (%s) with SimulateButton %s",
+                      self.name, self.stack, self.relay,
+                      onoff_to_str(self.init_state), self.sim_button)
+        self.log.debug("%s has following configured connections: \n%s",
+                       self.name, yaml.dump(self.comm))
+
+        # publish inital state back to remote connections
+        self.publish_actuator_state()
+
+        configure_device_channel(self.comm, is_output=False,
+                                 name="set digital output", datatype=ChanType.ENUM,
+                                 restrictions="ON,OFF,TOGGLE")
+        #the actuator gets registered twice, at core-actuator and here
+        # currently this is the only way to pass the device_channel_config to homie_conn
+        self._register(self.comm, None)
+
+    def on_message(self, msg):
+        """Called when the actuator receives a message. If SimulateButton is not enabled
+        sets the relay ON of OFF corresponding to the message.
+        """
+        # ignore command echo which occure with multiple connections:
+        # do nothing when the command (msg) equals the current state,
+        # ignor this on SimulateButton mode
+        if not self.sim_button:
+            if msg in ("ON", "OFF"):
+                if self.current_state == strtobool(msg):
+                    self.log.info("%s received command %s"
+                                  " which is equal to current output state. Ignoring command!",
+                                  self.name, msg)
+                    return
+            elif is_toggle_cmd(msg):
+                # If the string has length 26 and the char at index 10
+                # is T then its porbably a ISO 8601 formated datetime value,
+                # which was send from RpiGpioSensor
+                time_now = datetime.datetime.now()
+                seconds_since_toggle = (time_now - self.last_toggle).total_seconds()
+                if seconds_since_toggle < self.toggle_debounce:
+                    # filter close toggle commands to make sure no double switching occures
+                    self.log.info("%s received toggle command %s"
+                                  " within debounce time. Ignoring command!",
+                                  self.name, msg)
+                    return
+
+                self.last_toggle = time_now
+                msg = "TOGGLE"
+
+        self.log.info("%s received command %s, SimulateButton = %s, Stack = %d, Relay = %d",
+                      self.name, msg, self.sim_button, self.stack, self.relay)
+
+        # SimulateButton on then off.
+        if self.sim_button:
+            self.log.info("%s toggles Stack %d Relay %d,  %s to %s",
+                          self.name, self.stack, self.relay,
+                          onoff_to_str(self.init_state),
+                          onoff_to_str(not self.init_state))
+            lib8relay.set(self.stack, self.mapped_relay, int(not self.init_state))
+            #  "sleep" will block a local connecten and therefore
+            # distort the time detection of button press event's
+            sleep(.5)
+            self.log.info("%s toggles Stack %d Relay %d,  %s to %s",
+                          self.name, self.stack, self.relay,
+                          onoff_to_str(not self.init_state),
+                          onoff_to_str(self.init_state))
+            lib8relay.set(self.stack, self.mapped_relay, self.init_state)
+
+        # Turn ON/OFF based on the message.
+        else:
+            out = None
+            if msg == "ON":
+                out = 1
+            elif msg == "OFF":
+                out = 0
+            elif msg == "TOGGLE":
+                out = int(not self.current_state)
+
+            if out is None:
+                self.log.error("%s bad command %s", self.name, msg)
+            else:
+                self.current_state = out
+
+                self.log.info("%s set stack %d relay %d to %s",
+                              self.name, self.stack, self.relay,
+                              onoff_to_str(out))
+                lib8relay.set(self.stack, self.mapped_relay, out)
+
+                #publish own state back to remote connections
+                self.publish_actuator_state()
+
+    def publish_actuator_state(self):
+        """Publishes the current state of the actuator."""
+        msg = "ON" if self.current_state else "OFF"
+        self._publish(msg, self.comm)

--- a/i2c/relay.py
+++ b/i2c/relay.py
@@ -60,8 +60,8 @@ class EightRelayHAT(Actuator):
 
         self.stack = dev_cfg.get("Stack", 0)
 
-        #relays on the HAT are scrambled up, map them correctly
-        # there is no relay 0 but array indexing starts at zero, first index is a filler
+        #relays on the HAT v5.3 are scrambled up, map them correctly
+        #there is no relay 0 but array indexing starts at zero, first index is a filler
         relay_map = [0, 1, 2, 5, 6, 7, 8, 4, 3]
 
         self.relay = int(dev_cfg["Relay"])

--- a/i2c/relay.py
+++ b/i2c/relay.py
@@ -43,8 +43,8 @@ class EightRelayHAT(Actuator):
 
     def __init__(self, connections, dev_cfg):
         """Initializes the I2C subsystem and sets the relay to the InitialState.
-        If InitialState is not povided in params it defaults to OFF. If
-        "SimulateButton" is defined on any message will result in the relay being set to
+        If InitialState is not povided in params it defaults to OFF.
+        If "SimulateButton" is defined on any message will result in the relay being set to
         ON for half a second and then back to OFF.
 
         Parameters:
@@ -100,7 +100,7 @@ class EightRelayHAT(Actuator):
         self.publish_actuator_state()
 
         configure_device_channel(self.comm, is_output=False,
-                                 name="set digital output", datatype=ChanType.ENUM,
+                                 name="set relay", datatype=ChanType.ENUM,
                                  restrictions="ON,OFF,TOGGLE")
         #the actuator gets registered twice, at core-actuator and here
         # currently this is the only way to pass the device_channel_config to homie_conn
@@ -121,9 +121,7 @@ class EightRelayHAT(Actuator):
                                   self.name, msg)
                     return
             elif is_toggle_cmd(msg):
-                # If the string has length 26 and the char at index 10
-                # is T then its porbably a ISO 8601 formated datetime value,
-                # which was send from RpiGpioSensor
+                # remember time for toggle debounce
                 time_now = datetime.datetime.now()
                 seconds_since_toggle = (time_now - self.last_toggle).total_seconds()
                 if seconds_since_toggle < self.toggle_debounce:


### PR DESCRIPTION
this PR adds support and documentation for the [8-Relays-HAT](https://sequentmicrosystems.com/collections/industrial-automation/products/8-relays-stackable-card-for-raspberry-pi)  from Sequent Microsystems via i2c-bus.  It will work with up to 8 stacked relay boards. The code is based on the GPIO actuator.

The code was tested with the 8-Relays-HAT with Version 5.3