### PR TITLE
add support for 2CH-Triac-HAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Go into the subfolders for details in each subfolder's README.
 | [`openhab_rest.rest_conn.OpenhabREST`](openhab_rest/README.md#openhab-rest-connection)                    | Connection                    | Subscribes and publishes to openHAB's REST API. Subscription is through openHAB's SSE feed.               |
 | [`roku.roku_addr.RokuAddressSensor`](roku/README.md#roku-address-sensor-deprecated)                       | Polling Sensor                | Periodically requests the addresses of all the Rokus on the subnet.                                       |
 | [`ic2.relay.EightRelayHAT`](i2c/README.md#i2crelayeightrelayhat)                                          | Actuator                      | Sets a relay to a given state on command. Supports 8-Relays-HAT via i2c                                   |
+| [`ic2.triac.TriacDimmer`](i2c/README.md#i2ctriactriacdimmer)                                              | Actuator                      | Sets a triac PWM to a given duty cycle on command. Supports 2-Ch Triac HAT via i2c                        |
 
 # Architecture
 The main script is `sensor_reporter` which parses a configuration YAML file and handles operating system signal handling.
@@ -69,7 +70,7 @@ Each plugin will have it's own dependency.
 See the readmes in the subfolders for details.
 
 # Usage
-`python3 sensor_reporter configuration.yml`
+`python3 sensor_reporter.py configuration.yml`
 
 An example systemd service file is provided for your reference.
 The following steps describe how to setup the service:

--- a/gpio/rpi_gpio.py
+++ b/gpio/rpi_gpio.py
@@ -27,7 +27,7 @@ from core.actuator import Actuator
 from core.utils import parse_values, is_toggle_cmd, verify_connections_layout, \
                         get_msg_from_values, DEFAULT_SECTION, configure_device_channel, ChanType
 
-#constants
+# constants
 OUT_SWITCH = "Switch"
 OUT_SHORT_PRESS = "ShortButtonPress"
 OUT_LONG_PRESS = "LongButtonPress"
@@ -128,7 +128,7 @@ class RpiGpioSensor(Sensor):
 
         self.btn = ButtonPressCfg(dev_cfg, self)
 
-        #verify that defined output channels in Connections section are valid!
+        # verify that defined output channels in Connections section are valid!
         verify_connections_layout(self.comm, self.log, self.name,
                                   [OUT_SWITCH, OUT_SHORT_PRESS, OUT_LONG_PRESS])
 
@@ -142,7 +142,7 @@ class RpiGpioSensor(Sensor):
 
         self.publish_state()
 
-        #configure_output for homie etc. after debug output, so self.comm is clean
+        # configure_output for homie etc. after debug output, so self.comm is clean
         configure_device_channel(self.comm, is_output=True, output_name=OUT_SWITCH,
                                  name="switch state")
         configure_device_channel(self.comm, is_output=True, output_name=OUT_SHORT_PRESS,
@@ -199,14 +199,14 @@ class ButtonPressCfg():
             - caller     : the objetc of the calling sensor
         """
         self.high_time = None
-        #expect threshold in seconds
+        # expect threshold in seconds
         self.short_press_time = float(dev_cfg.get("Short_Press-Threshold", 0))
         self.long_press_time = float(dev_cfg.get("Long_Press-Threshold",0))
 
         try:
             self.state_when_pressed = GPIO.LOW if dev_cfg["Btn_Pressed_State"]=="LOW" else GPIO.HIGH
         except KeyError:
-            #if value not in the config, determind it from PUD
+            # if value not in the config, determind it from PUD
             self.state_when_pressed = GPIO.LOW if caller.pud == GPIO.PUD_UP else GPIO.HIGH
 
         caller.log.info('%s configued button press events, with short press threshold %s, '
@@ -222,7 +222,7 @@ class ButtonPressCfg():
              - caller : the object of the caller
                         so self.log and self.publish_button_state can be accessed
          """
-        #get time during button was closed
+        # get time during button was closed
         if caller.state == self.state_when_pressed:
             self.high_time = datetime.datetime.now()
         elif self.high_time is None:
@@ -289,11 +289,11 @@ class RpiGpioActuator(Actuator):
         except KeyError:
             self.sim_button = dev_cfg.get("Toggle", False)
 
-        #default debaunce time 0.15 seconds
+        # default debaunce time 0.15 seconds
         self.toggle_debounce = float(dev_cfg.get("ToggleDebounce", 0.15))
         self.last_toggle = datetime.datetime.fromordinal(1)
 
-        #remember the current output state
+        # remember the current output state
         if self.sim_button:
             self.current_state = None
         else:
@@ -313,7 +313,7 @@ class RpiGpioActuator(Actuator):
         configure_device_channel(self.comm, is_output=False,
                                  name="set digital output", datatype=ChanType.ENUM,
                                  restrictions="ON,OFF,TOGGLE")
-        #the actuator gets registered twice, at core-actuator and here
+        # The actuator gets registered twice, at core-actuator and here
         # currently this is the only way to pass the device_channel_config to homie_conn
         self._register(self.comm, None)
 
@@ -357,7 +357,7 @@ class RpiGpioActuator(Actuator):
                           highlow_to_str(self.init_state),
                           highlow_to_str(not self.init_state))
             GPIO.output(self.pin, int(not self.init_state))
-            #  "sleep" will block a local connecten and therefore
+            # "sleep" will block a local connecten and therefore
             # distort the time detection of button press event's
             sleep(.5)
             self.log.info("%s toggles pin %s (%s) %s to %s",
@@ -388,7 +388,7 @@ class RpiGpioActuator(Actuator):
                               highlow_to_str(out))
                 GPIO.output(self.pin, out)
 
-                #publish own state back to remote connections
+                # publish own state back to remote connections
                 self.publish_actuator_state()
 
     def publish_actuator_state(self):

--- a/gpio/rpi_gpio.py
+++ b/gpio/rpi_gpio.py
@@ -255,12 +255,14 @@ class RpiGpioActuator(Actuator):
         HIGH for half a second and then back to LOW.
 
         Parameters:
-            - "Pin": The GPIO pin in BCM numbering
-            - "InitialState": The pin state to set when coming online, defaults
-            to "OFF".
+            - "Pin":            The GPIO pin in BCM numbering
+            - "InitialState":   The pin state to set when coming online,
+                                defaults to "OFF".
             - "SimulateButton": Optional parameter that when set to "True" causes any
-            message received to result in setting the pin to HIGH, sleep for
-            half a second, then back to LOW.
+                                message received to result in setting the pin to HIGH, sleep for
+                                half a second, then back to LOW.
+            - "ToggleDebounce": The interval in seconds during which repeated
+                                toggle commands are ignored (default 0.15 seconds)
         """
         super().__init__(connections, dev_cfg)
 

--- a/i2c/README.md
+++ b/i2c/README.md
@@ -2,6 +2,7 @@
 
 This module contains:
 * [i2c.relay.EightRelayHAT](#i2crelayeightrelayhat)
+* [i2c.triac.TriacDimmer](#i2ctriactriacdimmer)
 
 
 
@@ -60,6 +61,13 @@ Can be connected directly to a RpiGpioSensor ShortButtonPress / LongButtonPress 
 The output will send the relay state as ON / OFF after a change.
 When using with the openHAB connection configure a switch/string Item.
 
+### Hardware address
+
+The 8-Relays-HAT uses internally the i2c addresses from 56 to 63 or 32 to 39 depending on the hardware version (hexadecimal from 0x38 to 0x3F or 0x20 to 0x27).
+This address can be configured with jumpers see [here](https://sequentmicrosystems.com/collections/industrial-automation/products/8-relays-stackable-card-for-raspberry-pi).
+Stack 0 equals address (decimal) 56 or 32, stack 7 equals (decimal) 63 or 39.
+No other i2c devices with the same address can be installed at the same time.
+
 ### Configuration Examples
 
 ```yaml
@@ -81,4 +89,107 @@ ActuatorGarageDoor:
     Relay: 1
 ```
 
+## `i2c.triac.TriacDimmer`
 
+Commands a [Waveshare 2-Ch Triac HAT](https://www.waveshare.com/wiki/2-CH_TRIAC_HAT) to set the Triac PWM.
+A received command will be sent back on all configured connections to the configured return topic, to keep them up to date.
+
+### Dependencies
+
+This actuator communicates via the i2c interface, therfore the GPIO 2 and 3 should be free and cannot get accessed directly e. g. with a RpiGPIOSensor.
+Also the library `smbus2` must be installed to make this actuator work.
+
+To enable the i2c interface open the Raspberry-Pi configuration via:
+
+```bash
+sudo raspi-config
+```
+and choose Interface Options, then <b>I2C Interface</b> and yes.
+
+The user running sensor_reporter must have permission to access the i2c interface.
+To grant the `sensorReporter` user i2c permissions add the user to the group `i2c`:
+
+```bash
+sudo adduser sensorReporter i2c
+```
+
+Install `smbus2` via:
+
+```bash
+sudo pip3 install smbus2
+```
+
+### Parameters
+
+| Parameter              | Required | Restrictions                    | Purpose                                                                                                                                                                              |
+|------------------------|----------|---------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Class`                | X        | `i2c.triac.TriacDimmer`         |                                                                                                                                                                                      |
+| `Connections`          | X        | dictionary of connectors        | Defines where to subscribe for messages and where to publish the status for each connection. Look at connection readme's for 'Actuator / sensor relevant parameters' for details.    |
+| `Channel`              | X        | triac channel No. 1 or 2        | The triac channel to control                                                                                                                                                         |
+| `GridFreq`             |          | frequency in Hz 50 or 60        | The Power grid frequency in Herz 50 or 60, default 50                                                                                                                                |
+| `Level`                |          | DEBUG, INFO, WARNING, ERROR     | Override the global log level and use another one for this sensor.                                                                                                                   |
+| `ToggleDebounce`       |          | decimal number                  | The interval in seconds during which repeated toggle commands are ignored. (default 0.15 seconds)                                                                                    |
+| `InitialState`         |          | integer                         | When set the triac PWM is initialized to the given duty cycle in percent. (default 0)                                                                                                |
+| `SmoothChangeInterval` |          | decimal number                  | Time steps in seconds between PWM changes while smoothly switching on or off. If the value is 0, there is no smooth change when the setpoint changes. (default 0.05)                 |
+| `DimDelay`             |          | decimal number                  | Delay in seconds befor PWM dimming starts. (default 0.5)                                                                                                                             |
+| `DimInterval`          |          | decimal number                  | Time steps in seconds between PWM changes during dimming. (default 0.2)                                                                                                              |
+
+
+
+### Outputs / Inputs
+
+The TriacDimmer has only one output and input.
+The input expects a whole number, ON, OFF, DIM, STOP, TOGGLE or a datetime string as a command.
+A received number will set the Triac PWM duty cycle accordingly, 0% equals off.
+While ON, OFF will set the triac PWM to 100% or 0% respectively, TOGGLE and a datetime string will toggle the PWM to the last state.
+If DIM is received manual, dimming will start after `DimDelay` and the PWM will dim every `DimInterval` seconds in 5% steps until the STOP command is sent.
+If the current PWM value is greater then zero manual dimming will dim down to 0% and then up to 100%.
+Otherwise, if the PWM value is zero, manual dimming will dim up to 100%. 
+The STOP command will also interrupt the `DimDelay`, so no manual dimming will occur.
+Can be connected directly to a RpiGpioSensor ShortButtonPress / LongButtonPress output.
+The output will send the Triac PWM duty cycle as number (0 - 100) after a change.
+When using with the openHAB connection configure a dimmer/string Item.
+
+### Hardware address
+
+The 2-Ch Triac HAT uses the i2c address 71 internally (hexadecimal 0x47).
+This address is hardcoded into the HAT and cannot be changed.
+No other i2c devices with the same address can be installed at the same time.
+
+### Configuration Examples
+The following config will toggle the dimmer if the LightPushButton is pressed for less then 0.4 seconds (`Long_Press-Threshold`).
+If it is pressed longer than 0.5 seconds (`DimDelay`) the manual dimming will start and stop only when the button is released.
+
+```yaml
+Logging:
+    Syslog: yes
+    Level: INFO
+
+Connection_local:
+    Class: local.local_conn.LocalConnection
+    Name: local
+
+ActuatorLightDimmer:
+    Class: Class: i2c.triac.TriacDimmer
+    Connections:
+        local:
+            CommandSrc: dimmer1
+    Channel: 1
+
+SensorLightPushButton:
+    Class: gpio.rpi_gpio.RpiGpioSensor
+    Connections: 
+        local:
+            Switch:
+                StateDest: dimmer1
+            ShortButtonPress:
+                StateDest: dimmer1
+    Pin: 17
+    PUD: UP
+    EventDetection: BOTH
+    Long_Press-Threshold: 0.4
+    Values:
+        local:
+            - 'DIM'
+            - 'STOP'
+```

--- a/i2c/README.md
+++ b/i2c/README.md
@@ -126,13 +126,13 @@ sudo pip3 install smbus2
 | `Class`                | X        | `i2c.triac.TriacDimmer`         |                                                                                                                                                                                      |
 | `Connections`          | X        | dictionary of connectors        | Defines where to subscribe for messages and where to publish the status for each connection. Look at connection readme's for 'Actuator / sensor relevant parameters' for details.    |
 | `Channel`              | X        | triac channel No. 1 or 2        | The triac channel to control                                                                                                                                                         |
-| `GridFreq`             |          | frequency in Hz 50 or 60        | The Power grid frequency in Herz 50 or 60, default 50                                                                                                                                |
+| `MainsFreq`            |          | frequency in Hz 50 or 60        | The Power grid frequency in Herz 50 or 60, default 50                                                                                                                                |
 | `Level`                |          | DEBUG, INFO, WARNING, ERROR     | Override the global log level and use another one for this sensor.                                                                                                                   |
 | `ToggleDebounce`       |          | decimal number                  | The interval in seconds during which repeated toggle commands are ignored. (default 0.15 seconds)                                                                                    |
 | `InitialState`         |          | integer                         | When set the triac PWM is initialized to the given duty cycle in percent. (default 0)                                                                                                |
 | `SmoothChangeInterval` |          | decimal number                  | Time steps in seconds between PWM changes while smoothly switching on or off. If the value is 0, there is no smooth change when the setpoint changes. (default 0.05)                 |
-| `DimDelay`             |          | decimal number                  | Delay in seconds befor PWM dimming starts. (default 0.5)                                                                                                                             |
-| `DimInterval`          |          | decimal number                  | Time steps in seconds between PWM changes during dimming. (default 0.2)                                                                                                              |
+| `DimDelay`             |          | decimal number                  | Delay in seconds before manual PWM dimming starts. (default 0.5)                                                                                                                     |
+| `DimInterval`          |          | decimal number                  | Time steps in seconds between PWM changes during manual dimming. (default 0.2)                                                                                                       |
 
 
 
@@ -142,10 +142,12 @@ The TriacDimmer has only one output and input.
 The input expects a whole number, ON, OFF, DIM, STOP, TOGGLE or a datetime string as a command.
 A received number will set the Triac PWM duty cycle accordingly, 0% equals off.
 While ON, OFF will set the triac PWM to 100% or 0% respectively, TOGGLE and a datetime string will toggle the PWM to the last state.
+
 If DIM is received manual, dimming will start after `DimDelay` and the PWM will dim every `DimInterval` seconds in 5% steps until the STOP command is sent.
 If the current PWM value is greater then zero manual dimming will dim down to 0% and then up to 100%.
 Otherwise, if the PWM value is zero, manual dimming will dim up to 100%. 
 The STOP command will also interrupt the `DimDelay`, so no manual dimming will occur.
+
 Can be connected directly to a RpiGpioSensor ShortButtonPress / LongButtonPress output.
 The output will send the Triac PWM duty cycle as number (0 - 100) after a change.
 When using with the openHAB connection configure a dimmer/string Item.
@@ -170,7 +172,7 @@ Connection_local:
     Name: local
 
 ActuatorLightDimmer:
-    Class: Class: i2c.triac.TriacDimmer
+    Class: i2c.triac.TriacDimmer
     Connections:
         local:
             CommandSrc: dimmer1

--- a/i2c/relay.py
+++ b/i2c/relay.py
@@ -48,13 +48,15 @@ class EightRelayHAT(Actuator):
         ON for half a second and then back to OFF.
 
         Parameters:
-            - "Stack": Stack Address 0..7
-            - "Relay": Relay No. 1..8
-            - "InitialState": The pin state to set when coming online, defaults
-            to "OFF", optional.
+            - "Stack":          Stack Address 0..7
+            - "Relay":          Relay No. 1..8
+            - "InitialState":   The relay state to set when coming online,
+                                defaults to "OFF", optional.
             - "SimulateButton": Optional parameter that when set to "True" causes any
-            message received to result in setting the pin to HIGH, sleep for
-            half a second, then back to LOW.
+                                message received to result in setting the pin to HIGH, sleep for
+                                half a second, then back to LOW.
+            - "ToggleDebounce": The interval in seconds during which repeated
+                                toggle commands are ignored (default 0.15 seconds)
         """
         super().__init__(connections, dev_cfg)
 

--- a/i2c/relay.py
+++ b/i2c/relay.py
@@ -62,14 +62,14 @@ class EightRelayHAT(Actuator):
 
         self.stack = dev_cfg.get("Stack", 0)
 
-        #relays on the HAT v5.3 are scrambled up, map them correctly
-        #there is no relay 0 but array indexing starts at zero, first index is a filler
+        # relays on the HAT v5.3 are scrambled up, map them correctly
+        # there is no relay 0 but array indexing starts at zero, first index is a filler
         relay_map = [0, 1, 2, 5, 6, 7, 8, 4, 3]
 
         self.relay = int(dev_cfg["Relay"])
         self.mapped_relay = relay_map[self.relay]
 
-        #default state if not configured = False = off
+        # default state if not configured = False = off
         self.init_state =  dev_cfg.get("InitialState", False)
 
         try:
@@ -82,11 +82,11 @@ class EightRelayHAT(Actuator):
 
         self.sim_button = dev_cfg.get("SimulateButton", False)
 
-        #default debaunce time 0.15 seconds
+        # default debaunce time 0.15 seconds
         self.toggle_debounce = float(dev_cfg.get("ToggleDebounce", 0.15))
         self.last_toggle = datetime.datetime.fromordinal(1)
 
-        #remember the current output state
+        # remember the current output state
         if self.sim_button:
             self.current_state = None
         else:
@@ -104,7 +104,7 @@ class EightRelayHAT(Actuator):
         configure_device_channel(self.comm, is_output=False,
                                  name="set relay", datatype=ChanType.ENUM,
                                  restrictions="ON,OFF,TOGGLE")
-        #the actuator gets registered twice, at core-actuator and here
+        # The actuator gets registered twice, at core-actuator and here
         # currently this is the only way to pass the device_channel_config to homie_conn
         self._register(self.comm, None)
 
@@ -146,7 +146,7 @@ class EightRelayHAT(Actuator):
                           onoff_to_str(self.init_state),
                           onoff_to_str(not self.init_state))
             lib8relay.set(self.stack, self.mapped_relay, int(not self.init_state))
-            #  "sleep" will block a local connecten and therefore
+            # "sleep" will block a local connecten and therefore
             # distort the time detection of button press event's
             sleep(.5)
             self.log.info("%s toggles Stack %d Relay %d,  %s to %s",
@@ -175,7 +175,7 @@ class EightRelayHAT(Actuator):
                               onoff_to_str(out))
                 lib8relay.set(self.stack, self.mapped_relay, out)
 
-                #publish own state back to remote connections
+                # publish own state back to remote connections
                 self.publish_actuator_state()
 
     def publish_actuator_state(self):

--- a/i2c/triac.py
+++ b/i2c/triac.py
@@ -349,13 +349,13 @@ class TriacDimmer(Actuator):
         self.freq = dev_cfg.get("MainsFreq", 50)
 
         # default state if not configured = 0%
-        self.state = SimpleNamespace(initial=None, current=None, last=None, before_dimming=0)
-        self.state.initial =  int(dev_cfg.get("InitialState", 0))
+        self.state = SimpleNamespace(current=None, last=None)
+        inital_state =  int(dev_cfg.get("InitialState", 0))
 
         try:
             self.driver = i2c_driver()
             self.driver.set_power_grid_frequency(self.log, self.freq)
-            self.driver.set_duty_cycle(self.log, self.channel, self.state.initial)
+            self.driver.set_duty_cycle(self.log, self.channel, inital_state)
         except AttributeError:
             self.log.error("%s could not setup TriacDimmer. "
                            "Ensure that the Triac HAT is correctly installed. "
@@ -368,11 +368,11 @@ class TriacDimmer(Actuator):
         self.toggle.last_time = datetime.datetime.fromordinal(1)
 
         # remember the current output state, set last laste for toggle command
-        self.state.current = self.state.initial
-        if self.state.initial == 0:
+        self.state.current = inital_state
+        if inital_state == 0:
             self.state.last = 100
         else:
-            self.state.last = self.state.initial
+            self.state.last = inital_state
 
         # define callback method for smooth dimmer thread
         def set_pwm_value(value):
@@ -381,7 +381,7 @@ class TriacDimmer(Actuator):
         self.dimmer = _SmoothDimmer(caller = self, callback_set_pwm = set_pwm_value)
 
         self.log.info("Configued TriacDimmer %s: channel %d, mains frequency %dHz, PWM %s%%",
-                      self.name, self.channel, self.freq, self.state.initial)
+                      self.name, self.channel, self.freq, inital_state)
         self.log.debug("%s has following configured connections: \n%s",
                        self.name, yaml.dump(self.comm))
 

--- a/i2c/triac.py
+++ b/i2c/triac.py
@@ -1,0 +1,400 @@
+# Copyright 2023 Daniel Decker
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Contains TriacHAT.
+
+Classes:
+    - TriacHAT: 2 channel triac for light dimming.
+"""
+import datetime
+from types import SimpleNamespace
+from threading import Thread
+from time import sleep
+import smbus2       # https://smbus2.readthedocs.io/en/latest/
+import yaml
+from core.actuator import Actuator
+from core.utils import is_toggle_cmd, configure_device_channel, ChanType
+
+# Constans for 2-CH_TRIAC_HAT Register addresses
+# https://www.waveshare.com/wiki/2-CH_TRIAC_HAT
+REG_MODE = 0x01
+REG_CHANNEL_ENABLE = 0x02
+REG_CHANNEL1_ANGLE = 0x03
+REG_CHANNEL2_ANGLE = 0x04
+REG_GRID_FREQUENCY = 0x05
+REG_RESET = 0x06
+CHANNEL1_ENABLE = 0x01
+CHANNEL2_ENABLE = 0x02
+
+class _I2cDriver():
+    """
+        The i2c driver handles communication with the waveshare 2-CH triac HAT.
+        Documentation of the device is aviable at:
+        https://www.waveshare.com/wiki/2-CH_TRIAC_HAT
+
+        Depends on smbus2,
+        uses I2C address 0x47, which is hardcoded on the hardware
+
+        Public interfaces:
+            - set_duty_cycle
+            - set_power_grid_frequency
+    """
+    def __init__(self):
+        self.bus = smbus2.SMBus(1)   # 0 = /dev/i2c-0 (port I2C0), 1 = /dev/i2c-1 (port I2C1)
+        # the triac uses bus address 0x47, the HAT is hardcoded to this address
+        self.addr = 0x47
+        # remember enabled channels / 0 = off, 1 = ch1 on, 2 = ch2 on, 3= ch1 & ch2 on
+        self.enabled_channels = 0x00
+
+        #set mode to "Voltage adjustment"
+        self._bus_write(REG_MODE, 1)
+
+    def _bus_write(self, reg, data):
+        """ The triac HAT expects the date to be written in the following structure:
+         +----------+---------------+-----------+----------+
+         | I2C addr | register addr | high byte | low byte |
+         +----------+---------------+-----------+----------+
+                                    |    payload data      |
+                                    +----------------------+
+         the payload has to be a word (2 byte), but the used registers only evaluate
+         the high byte. It seems the low byte is ignored. Therefore bit shift the
+         data one byte (8 bit) left.
+
+        Parameters:
+            - "reg":    register to write to (see REG-constants above)
+            - "date":   the data to write into the given register (number 1 byte)
+        """
+        self.bus.write_word_data(self.addr, reg, (data << 8))
+
+
+    def set_duty_cycle(self, log, channel, duty_cycle_pct):
+        """changes the PWM duty cycle & enabled / disables the given channel on demand
+
+        Parameters:
+            - "log":            the self.log instance of the calling actuator
+            - "channel":        the channel of the triac HAT, allowed values 1 & 2
+            - "duty_cycle_pct": duty cycle in percent, allowed values 0 - 100
+
+        duty_cycle_pct = 0 will switch off the channel, while 100 will set it to alway on
+        """
+        #validate given channel
+        if channel < 1 or channel > 2:
+            log.error("Channel out of bounds, allowed 1 & 2! Value: %s", channel)
+            return
+        #validate given duty_cycle_pct
+        if duty_cycle_pct < 0 or duty_cycle_pct > 100:
+            log.error("PWM (duty_cycle_pct) out of bounds, allowed 0-100, value: %s",
+                      duty_cycle_pct)
+            return
+
+        channels_last_state = self.enabled_channels
+        # check if channel 1 or 2 needs the be enabled / disabled
+        if  duty_cycle_pct > 0:
+            if channel == 1:
+                #enable channel 1
+                self.enabled_channels = self.enabled_channels | CHANNEL1_ENABLE
+            else:
+                #enable channel 2
+                self.enabled_channels = self.enabled_channels | CHANNEL2_ENABLE
+        else:
+            if channel == 1:
+                #preserve channel 2 setting, disable ch 1
+                self.enabled_channels = self.enabled_channels & CHANNEL2_ENABLE
+            else:
+                #preserve channel 1 setting, disable ch 2
+                self.enabled_channels = self.enabled_channels & CHANNEL1_ENABLE
+
+        # only write channel register on change
+        if channels_last_state != self.enabled_channels:
+            log.debug("Triac driver updated enabled_channels to %d", self.enabled_channels)
+            self._bus_write(REG_CHANNEL_ENABLE, self.enabled_channels)
+            #wait 50ms so the HAT can proecess the command
+            sleep(0.05)
+
+        # the triac expects values from 0 to 179,
+        # convert duty_cycle_pct to expected angel values
+        angle = round( duty_cycle_pct / 100 * 179 )
+
+        #select the correct register for the given channel
+        if channel == 1:
+            self._bus_write(REG_CHANNEL1_ANGLE, angle)
+        elif channel == 2:
+            self._bus_write(REG_CHANNEL2_ANGLE, angle)
+
+        log.debug("Triac driver dimming channel %d to PWM %d%%",
+                           channel, duty_cycle_pct)
+
+    def set_power_grid_frequency(self, log, frequency):
+        """Tells the triac the grid frequency, to set the PWM accordingly
+
+        Parameters:
+            - "log":        the self.log instance of the calling actuator
+            - "frequency":  the power grid frequency in Hz,  allowed values 50 & 60
+        """
+        if frequency in [50, 60]:
+            self._bus_write(REG_GRID_FREQUENCY, frequency)
+            #wait 50ms so the HAT can proecess the command
+            sleep(0.05)
+        else:
+            log.warning("Unsupported grid frequency %s! Frequency not set", frequency)
+
+# create one instance of _I2cDriver() for later use
+_driver_singleton = _I2cDriver()
+def i2c_driver():
+    """ use singleton pattern to make sure only one instance for _I2cDriver()
+        is created even with multiple TriacDimmer
+        https://code.activestate.com/recipes/52558/#c7
+    """
+    return _driver_singleton
+
+
+class TriacDimmer(Actuator):
+    """Allows dimming one triac channel on Waveshare 2CH-Triac-HAT. Also supports
+    toggling.
+    """
+
+    def __init__(self, connections, dev_cfg):
+        """Initializes the I2C subsystem and sets the triac to the InitialState.
+        If InitialState is not povided in params it defaults to 0%.
+
+        Parameters:
+            - "Channel":                Triac channel No. 1 or 2
+            - "GridFreq":               Power grid frequency in Hz 50 or 60, default 50
+            - "InitialState":           PWM duty cycle in % when coming online,
+                                        defaults to "0", optional.
+            - "ToggleDebounce":         The interval in seconds during which repeated
+                                        toggle commands are ignored (default 0.15 seconds)
+            - "SmoothChangeInterval":   time steps in seconds between PWM changes
+                                        while smoothly switching on or off
+            - "DimDelay":               delay in seconds befor starting to dim the PWM
+            - "DimInterval":            time steps in seconds between PWM changes while dimming
+        """
+        super().__init__(connections, dev_cfg)
+
+        self.channel = int(dev_cfg["Channel"])
+        self.freq = dev_cfg.get("GridFreq", 50)
+
+        #default state if not configured = 0%
+        self.state = SimpleNamespace(initial=None, current=None, last=None, before_dimming=0)
+        self.state.initial =  int(dev_cfg.get("InitialState", 0))
+
+        try:
+            self.driver = i2c_driver()
+            self.driver.set_power_grid_frequency(self.log, self.freq)
+            self.driver.set_duty_cycle(self.log, self.channel, self.state.initial)
+        except ValueError as err:
+            self.log.error("%s could not setup TriacDimmer. "
+                           "Make sure the channel "
+                           "number is correct. Error Message: %s",
+                           self.name, err)
+
+        #default debaunce time 0.15 seconds
+        self.toggle = SimpleNamespace(debounce=None, last_time=None)
+        self.toggle.debounce = float(dev_cfg.get("ToggleDebounce", 0.15))
+        self.toggle.last_time = datetime.datetime.fromordinal(1)
+
+        #remember the current output state, set last laste for toggle command
+        self.state.current = self.state.initial
+        if self.state.initial == 0:
+            self.state.last = 100
+        else:
+            self.state.last = self.state.initial
+
+        #read settings for the dimmer options
+        self.dimmer = SimpleNamespace(dim_interval = float(self.dev_cfg.get("DimInterval", 0.2)),
+                                      dim_delay = float(self.dev_cfg.get("DimDelay", 0.5)),
+                                      smooth_change_interval = float(self.dev_cfg.get(
+                                                                     "SmoothChangeInterval", 0.05)),
+                                      smooth_change_in_progress=False,
+                                      thread=None, stop_thread=False)
+
+        self.log.info("Configued TriacDimmer %s: channel %d, grid frequency %dHz, PWM %s%%",
+                      self.name, self.channel, self.freq, self.state.initial)
+        self.log.debug("%s has following configured connections: \n%s",
+                       self.name, yaml.dump(self.comm))
+
+        # publish inital state back to remote connections
+        self.publish_actuator_state()
+
+        configure_device_channel(self.comm, is_output=False,
+                                 name="set duty cycle", datatype=ChanType.INTEGER,
+                                 unit="%", restrictions="0:100")
+        #the actuator gets registered twice, at core-actuator and here
+        # currently this is the only way to pass the device_channel_config to homie_conn
+        self._register(self.comm, None)
+
+    def on_message(self, msg):
+        """Called when the actuator receives a message.
+        Sets the triac according to the message value
+        """
+        self.log.debug("%s triac channel %d received command %s",
+                           self.name, self.channel, msg)
+
+        if msg.isdigit():
+            #msg contrains digits convert it from string to int
+            value = int(msg)
+        elif msg == "ON":
+            #handle openHab item sending ON
+            value = 100
+        elif msg == "OFF":
+            #handle openHab item sending OFF
+            value = 0
+        elif msg == "DIM":
+            #ignore the DIM command if smooth_change_in_progress
+            if not self.dimmer.smooth_change_in_progress:
+                if isinstance(self.dimmer.thread, Thread):
+                    #Info: waiting for the thread will rais toggle time for local connections,
+                    # so there might occure no short toggle event.
+                    # But there should be no running thread anyway
+                    self.dimmer.thread.join(timeout=None)
+                #start manual dimming with start_delay
+                self.dimmer.stop_thread = False
+                #set target_value to 0 if current state > 0
+                if self.state.current:
+                    target_value = 0
+                else:
+                    target_value = 100
+                self.dimmer.thread = Thread(target=self._smooth_dimmer,
+                                            args=(self.dimmer.dim_delay,
+                                                  self.dimmer.dim_interval, target_value))
+                #  _smooth_dimmer args= start_delay, interval_time, target_value
+                self.state.before_dimming = self.state.current
+                self.dimmer.thread.start()
+
+            return
+        elif msg == "STOP":
+            #make sure we don't interrupt the smooth change
+            if not self.dimmer.smooth_change_in_progress:
+                #stop dimming thread and publish actuator state
+                self.dimmer.stop_thread = True
+                if isinstance(self.dimmer.thread, Thread):
+                    # wait max. 200ms for thread,
+                    # so local connection call wont get stuck here.
+                    # otherwise short toggle event with local connections are not possible
+                    self.dimmer.thread.join(timeout=0.2)
+                    # if thread is not alive = no timeout
+                    if not self.dimmer.thread.is_alive():
+                        #after thread closes check if the state (value) has changed
+                        if self.state.before_dimming != self.state.current:
+                            self.log.info("%s dimmed triac channel %d to PWM %d%%",
+                                          self.name, self.channel, self.state.current)
+                            self.publish_actuator_state()
+                    else:
+                        self.log.debug("%s triac smooth dimmer thread still active,"
+                                       " PWM value not published", self.name)
+
+            return
+        elif is_toggle_cmd(msg):
+            #remember time for toggle debounce
+            time_now = datetime.datetime.now()
+            seconds_since_toggle = (time_now - self.toggle.last_time).total_seconds()
+            if seconds_since_toggle < self.toggle.debounce:
+                #filter close toggle commands to make sure no double switching occures
+                self.log.info("%s triac channel %d received toggle command %s"
+                              " within debounce time. Ignoring command!",
+                             self.name, self.channel, msg)
+                return
+            self.toggle.last_time = time_now
+            #invert current state on toggle command
+            if self.state.current > 0:
+                value = 0
+            else:
+                value = self.state.last
+            #remeber last value for later if not zero
+            if self.state.current:
+                self.state.last = self.state.current
+        else:
+            #if command is not recognized ignor it
+            self.log.warning("%s  triac channel %d received unrecognized command %s",
+                             self.name, self.channel, msg)
+            return
+
+        # do nothing when the command (value) equals the current state
+        if self.state.current == value:
+            self.log.info("%s triac channel %d received setpoint %d%%"
+                          " which is equal to current PWM value. Ignoring command!",
+                          self.name, self.channel, value)
+            return
+
+        self.log.info("%s set triac channel %d to PWM %d%%",
+                      self.name, self.channel, value)
+
+        if self.dimmer.smooth_change_interval:
+            #start smooth dim thread, if self.dimmer.smooth_change_interval != 0
+            self.dimmer.stop_thread = True
+            if isinstance(self.dimmer.thread, Thread):
+                #make sure thread is not running before starting another one
+                self.dimmer.thread.join(timeout=None)
+            self.dimmer.stop_thread = False
+            self.dimmer.thread = Thread(target=self._smooth_dimmer,
+                                        args=(0, self.dimmer.smooth_change_interval, value))
+            #                                 |  |                                   |
+            # smooth_dimmer args=   start_delay  interval_time                       target_value
+            self.dimmer.smooth_change_in_progress = True
+            self.dimmer.thread.start()
+        else:
+            #set duty cycle based on the message
+            self.driver.set_duty_cycle(self.log, self.channel, value)
+
+        self.state.current = value
+        self.publish_actuator_state()
+
+
+    def publish_actuator_state(self):
+        """Publishes the current state of the actuator."""
+        #openHab only likes string messages, so convert the int
+        msg = str(self.state.current)
+        self._publish(msg, self.comm)
+
+    def _smooth_dimmer(self, start_delay, interval_time, target_value):
+        """change triac PWM smoothly to the target_value
+
+        Is used to create a thread for smoothly changeing the PWM when:
+        * changeing to defined setpoint (start_delay = 0)
+        * when dimming down to unknown target_value
+
+        Parameter:
+            - "start_delay":     delay in seconds befor starting the dimming (min 0.1)
+            - "interval_time":   time in seconds beween PWM steps
+            - "target_value":    the PWM percentage to dim to
+        """
+        # manual dimming starts only after a delay,
+        # to make sure regular toggle cmd's still get thru
+        waited = 0
+        while waited < start_delay and not self.dimmer.stop_thread:
+            #sleep in 100ms steps to make the start_delay interruptable
+            sleep(0.1)
+            waited += 0.1
+        current_value = self.state.current
+
+        #loop until target value is reached or external stop trigger
+        while current_value != target_value and not self.dimmer.stop_thread:
+            sleep(interval_time)
+            if abs(current_value - target_value) < 5:
+                current_value = target_value
+            else:
+                if current_value < target_value:
+                    current_value += 5
+                else:
+                    current_value -= 5
+            self.driver.set_duty_cycle(self.log, self.channel, current_value)
+            if start_delay and current_value == 0 and target_value == 0:
+                # if start_delay > 0 assume manual dimming,
+                # set target to 100 for bidirectional dimming
+                target_value = 100
+
+        #save value since its now the current state
+        self.state.current = current_value
+        self.dimmer.smooth_change_in_progress = False

--- a/local/README.md
+++ b/local/README.md
@@ -21,14 +21,14 @@ Toggle events, e.g. from a RpiGpioSensor will get forwarded in any case.
 
 ### Parameters
 
-Parameter | Required | Restrictions | Purpose
--|-|-|-
-`Class` | X | `local.local_conn.LocalConnection` |
-`Level` | | DEBUG, INFO, WARNING, ERROR | When provided, sets the logging level for the connection.
-`Name` | X | | Name used to reference this connection in Actuators and Sensor's Connection parameter.
-`OnEq` | | String, use ' ' | Sends an ON message to the actuator(s) when the sensor value matches this parameter. 
-`OnGt` | | Number | Sends an ON message to the actuator(s) when sensor value is greater than this parameter.
-`OnLt` | | Number | Sends an ON message to the actuator(s) when the sensor value is lower than this parameter.
+| Parameter | Required | Restrictions                       | Purpose                                                                                    |
+|-----------|----------|------------------------------------|--------------------------------------------------------------------------------------------|
+| `Class`   | X        | `local.local_conn.LocalConnection` |                                                                                            |
+| `Level`   |          | DEBUG, INFO, WARNING, ERROR        | When provided, sets the logging level for the connection.                                  |
+| `Name`    | X        | Unique to sensor_reporter          | Name used to reference this connection in Actuators and Sensor's Connection parameter.     |
+| `OnEq`    |          | String, use ' '                    | Sends an ON message to the actuator(s) when the sensor value matches this parameter.       |
+| `OnGt`    |          | Number                             | Sends an ON message to the actuator(s) when sensor value is greater than this parameter.   |
+| `OnLt`    |          | Number                             | Sends an ON message to the actuator(s) when the sensor value is lower than this parameter. |
 
 One of `OnEq`, `OnGt`, or `OnLt` need to be present and `True`.
 If more than one is present and `True` the first one marked as `True` is selected in the order listed (e.g. if `OnGt` and `OnLt` are both `True`, `OnGt` will be used and `OnLt` will be ignored).
@@ -41,10 +41,10 @@ If none of the three optional parameters are supplied, the recieved messages wil
 To use an actuator or a sensor (a device) with a connection it has to define this in the device 'Connections:' parameter with a dictionary of connection names and connection related parameters (see Dictionary of connectors layout).
 The local connection uses following parameters:
 
-Parameter | Required | Restrictions | Purpose
--|-|-|-
-`CommandSrc` | yes for actuators |  | specifies the topic to subscribe for actuator events
-`StateDest` |  |  | optional return topic to publish the current device state / sensor readings. If not present the state won't get published.
+| Parameter    | Required          | Restrictions | Purpose                                                                                                                    |
+|--------------|-------------------|--------------|----------------------------------------------------------------------------------------------------------------------------|
+| `CommandSrc` | yes for actuators |              | specifies the topic to subscribe for actuator events                                                                       |
+| `StateDest`  |                   |              | optional return topic to publish the current device state / sensor readings. If not present the state won't get published. |
 
 #### Dictionary of connectors layout
 To configure a local connection in a sensor / actuator use following layout:

--- a/mqtt/README.md
+++ b/mqtt/README.md
@@ -19,21 +19,21 @@ sudo pip3 install paho-mqtt
 
 ### Parameters
 
-Parameter | Required | Restrictions | Purpose
--|-|-|-
-`Class` | X | `mqtt.mqtt_conn.MqttConnection` |
-`Level` | | DEBUG, INFO, WARNING, ERROR | When provided, sets the logging level for the connection.
-`Name` | X | | Unique to sensor_reporter | Name for the connection, used in the list of Connections for Actuators and Sensors.
-`Client` | X | Unique to the broker | Name used when connecting to the MQTT broker.
-`User` | X | | MQTT broker login name.
-`Password` | X | | Password for the broker login.
-`Host` | X | | Hostname or IP address for the MQTT broker.
-`Port` | X | Integer | Port number the MQTT broker is listening on.
-`Keepalive` | X | Seconds | How frequently to exchange keep alive messages with the broker. The smaller the number the faster the broker will detect this client has gone offline but the more network traffic will be consumed.
-`RootTopic` | X | Valid MQTT topic, no wild cards | Serves as the root topic for all the messages published. For example, if an RpiGpioSensor has a destination "back-door", the actual topic published to will be `<RootTopic>/back-door`.
-`TLS` | | Boolean | If set to `True`, will use TLS encryption in the connection to the MQTT broker.  
-`CAcert` | | String | Optional path to the Certificate Authority's certificate that signed the MQTT Broker's certificate. Default is `./certs/ca.crt`.  
-`TLSinsecure` | | Boolean | Optional parameter to configure verification of the server hostname in the server certificate. Default is `False`.  
+| Parameter     | Required | Restrictions                    | Purpose                                                                                                                                                                                              |
+|---------------|----------|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Class`       | X        | `mqtt.mqtt_conn.MqttConnection` |                                                                                                                                                                                                      |
+| `Level`       |          | DEBUG, INFO, WARNING, ERROR     | When provided, sets the logging level for the connection.                                                                                                                                            |
+| `Name`        | X        | Unique to sensor_reporter       | Name for the connection, used in the list of Connections for Actuators and Sensors.                                                                                                                  |
+| `Client`      | X        | Unique to the broker            | Name used when connecting to the MQTT broker.                                                                                                                                                        |
+| `User`        | X        |                                 | MQTT broker login name.                                                                                                                                                                              |
+| `Password`    | X        |                                 | Password for the broker login.                                                                                                                                                                       |
+| `Host`        | X        |                                 | Hostname or IP address for the MQTT broker.                                                                                                                                                          |
+| `Port`        | X        | Integer                         | Port number the MQTT broker is listening on.                                                                                                                                                         |
+| `Keepalive`   | X        | Seconds                         | How frequently to exchange keep alive messages with the broker. The smaller the number the faster the broker will detect this client has gone offline but the more network traffic will be consumed. |
+| `RootTopic`   | X        | Valid MQTT topic, no wild cards | Serves as the root topic for all the messages published. For example, if an RpiGpioSensor has a destination "back-door", the actual topic published to will be `<RootTopic>/back-door`.              |
+| `TLS`         |          | Boolean                         | If set to `True`, will use TLS encryption in the connection to the MQTT broker.                                                                                                                      |
+| `CAcert`      |          | String                          | Optional path to the Certificate Authority's certificate that signed the MQTT Broker's certificate. Default is `./certs/ca.crt`.                                                                     |
+| `TLSinsecure` |          | Boolean                         | Optional parameter to configure verification of the server hostname in the server certificate. Default is `False`.                                                                                   |
 
 There are two hard coded topics the Connection will use:
 
@@ -45,11 +45,11 @@ There are two hard coded topics the Connection will use:
 To use an actuator or a sensor (a device) with a connection it has to define this in the device 'Connections:' parameter with a dictionary of connection names and connection related parameters (see Dictionary of connectors layout).
 The MQTT connection uses following parameters:
 
-Parameter | Required | Restrictions | Purpose
--|-|-|-
-`CommandSrc` | yes for actuators |  | specifies the topic to subscribe for actuator events
-`StateDest` |  |  | return topic to publish the current device state / sensor readings. If not present the state won't get published.
-`Retain` |  | boolean | If True, MQTT will publish messages with the retain flag. Default is False.
+| Parameter    | Required          | Restrictions | Purpose                                                                                                           |
+|--------------|-------------------|--------------|-------------------------------------------------------------------------------------------------------------------|
+| `CommandSrc` | yes for actuators |              | specifies the topic to subscribe for actuator events                                                              |
+| `StateDest`  |                   |              | return topic to publish the current device state / sensor readings. If not present the state won't get published. |
+| `Retain`     |                   | boolean      | If True, MQTT will publish messages with the retain flag. Default is False.                                       |
 
 #### Dictionary of connectors layout
 To configure a MQTT connection in a sensor / actuator use following layout:
@@ -123,21 +123,21 @@ $ sudo pip3 install homie-spec
 
 ### Parameters
 
-Parameter | Required | Restrictions | Purpose
--|-|-|-
-`Class` | X | `mqtt.homie_conn.HomieConnection` |
-`Level` | | DEBUG, INFO, WARNING, ERROR | When provided, sets the logging level for the connection.
-`Name` | X | | Unique to sensor_reporter | Name for the connection, used in the list of Connections for Actuators and Sensors.
-`Client` |  | Unique to the broker | Name used when connecting to the MQTT broker. If not defined the `DeviceID` is used.
-`User` | X | | MQTT broker login name.
-`Password` | X | | Password for the broker login.
-`Host` | X | | Hostname or IP address for the MQTT broker.
-`Port` | X | Integer | Port number the MQTT broker is listening on.
-`Keepalive` | X | Seconds | How frequently to exchange keep alive messages with the broker. The smaller the number the faster the broker will detect this client has gone offline but the more network traffic will be consumed.
-`DeviceID` | X | Unique Homie name, a-z, 0-9 | This name will show up in the auto discover / inbox of the home automation software e. g. openHAB
-`TLS` | | Boolean | If set to `True`, will use TLS encryption in the connection to the MQTT broker.  
-`CAcert` | | String | Optional path to the Certificate Authority's certificate that signed the MQTT Broker's certificate. Default is `./certs/ca.crt`.  
-`TLSinsecure` | | Boolean | Optional parameter to configure verification of the server hostname in the server certificate. Default is `False`.  
+|   Parameter   | Required | Restrictions                          | Purpose                                                                                                                                                                                              |
+|---------------|----------|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Class`       | X        | `mqtt.homie_conn.HomieConnection`     |                                                                                                                                                                                                      |
+| `Level`       |          | DEBUG, INFO, WARNING, ERROR           | When provided, sets the logging level for the connection.                                                                                                                                            |
+| `Name`        | X        | Unique to sensor_reporter             | Name for the connection, used in the list of Connections for Actuators and Sensors.                                                                                                                  |
+| `Client`      |          | Unique to the broker                  | Name used when connecting to the MQTT broker. If not defined the `DeviceID` is used.                                                                                                                 |
+| `User`        | X        |                                       | MQTT broker login name.                                                                                                                                                                              |
+| `Password`    | X        |                                       | Password for the broker login.                                                                                                                                                                       |
+| `Host`        | X        |                                       | Hostname or IP address for the MQTT broker.                                                                                                                                                          |
+| `Port`        | X        | Integer                               | Port number the MQTT broker is listening on.                                                                                                                                                         |
+| `Keepalive`   | X        | Seconds                               | How frequently to exchange keep alive messages with the broker. The smaller the number the faster the broker will detect this client has gone offline but the more network traffic will be consumed. |
+| `DeviceID`    | X        | Unique Homie name, a-z, 0-9, "-", "_" | This name will show up in the auto discover / inbox of the home automation software e. g. openHAB                                                                                                    |
+| `TLS`         |          | Boolean                               | If set to `True`, will use TLS encryption in the connection to the MQTT broker.                                                                                                                      |
+| `CAcert`      |          | String                                | Optional path to the Certificate Authority's certificate that signed the MQTT Broker's certificate. Default is `./certs/ca.crt`.                                                                     |
+| `TLSinsecure` |          | Boolean                               | Optional parameter to configure verification of the server hostname in the server certificate. Default is `False`.                                                                                   |
 
 There are two hard coded topics the Connection will use:
 
@@ -149,10 +149,10 @@ There are two hard coded topics the Connection will use:
 To use an actuator or a sensor (a device) with a connection it has to define this in the device 'Connections:' parameter with a dictionary of connection names and connection related parameters (see Dictionary of connectors layout).
 The Homie connection uses following parameters:
 
-Parameter | Required | Restrictions | Purpose
--|-|-|-
-`Name` | x | a-Z, 0-9 | Specifies the visible name for the device
-`Type` |  |  | Type of the device (homie node), might change the behavior of the smart home server. (default value is empty string '')
+| Parameter | Required | Restrictions       | Purpose                                                                                                                                                                                                            |
+|-----------|----------|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Name`    | X        | a-Z, 0-9, "-", "_" | Specifies the visible name for the device                                                                                                                                                                          |
+| `Type`    |          |                    | Type of the device (homie node, see $type in [Node Attributes](https://homieiot.github.io/specification/#node-attributes)), might change the behavior of the smart home server. (default value is empty string '') |
 
 #### Dictionary of connectors layout
 To configure a Homie connection in a sensor / actuator use following layout:

--- a/openhab_rest/README.md
+++ b/openhab_rest/README.md
@@ -16,24 +16,24 @@ sudo pip3 install sseclient-py
 
 ## Parameters
 
-Parameter | Required | Restrictions | Purpose
--|-|-|-
-`Class` | X | `openhab_rest.rest_conn.OpenhabREST` |
-`Level` | | DEBUG, INFO, WARNING, ERROR | When provided, sets the logging level for the connection.
-`Name` | X | | Unique to sensor_reporter | Name for the connection, used in the list of Connections for Actuators and Sensors.
-`URL` | X | http URL | The base URL and port of the openHAB instance.
-`RefreshItem` | X | | Name of a Switch Item; sending an ON command to the Item will cause sensor_reporter to publish the most recent state of all the sensors.
-`openHAB-Version` | | float | Version of the OpenHAB server to connect to as floating point figure. Default is '2.0'.
-`API-Token` | | | The API token generated on the [web interface](https://www.openhab.org/docs/configuration/apitokens.html). Only needed if 'settings > API-security > implicit user role (advanced settings)' is disabled. If no API token is specified sensor_reporter tries to connect without authentication.
+| Parameter         | Required | Restrictions                         | Purpose                                                                                                                                                                                                                                                                                         |
+|-------------------|----------|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Class`           | X        | `openhab_rest.rest_conn.OpenhabREST` |                                                                                                                                                                                                                                                                                                 |
+| `Level`           |          | DEBUG, INFO, WARNING, ERROR          | When provided, sets the logging level for the connection.                                                                                                                                                                                                                                       |
+| `Name`            | X        | Unique to sensor_reporter            | Name for the connection, used in the list of Connections for Actuators and Sensors.                                                                                                                                                                                                             |
+| `URL`             | X        | http URL                             | The base URL and port of the openHAB instance.                                                                                                                                                                                                                                                  |
+| `RefreshItem`     | X        |                                      | Name of a Switch Item; sending an ON command to the Item will cause sensor_reporter to publish the most recent state of all the sensors.                                                                                                                                                        |
+| `openHAB-Version` |          | float                                | Version of the OpenHAB server to connect to as floating point figure. Default is '2.0'.                                                                                                                                                                                                         |
+| `API-Token`       |          |                                      | The API token generated on the [web interface](https://www.openhab.org/docs/configuration/apitokens.html). Only needed if 'settings > API-security > implicit user role (advanced settings)' is disabled. If no API token is specified sensor_reporter tries to connect without authentication. |
 
 ### Actuator / sensor relevant parameters
 
 To use an actuator or a sensor (a device) with a connection it has to define this in the device 'Connections:' parameter with a dictionary of connection names and connection related parameters (see Dictionary of connectors layout).
 The openHAB REST connection uses following parameters:
 
-Parameter | Required | Restrictions | Purpose
--|-|-|-
-`Item` | yes | Alphanumeric & underscores only | specifies the topic to subscribe for actuator events and the return topic to publish the current device state / sensor reading. Device state is published as item update. Actuators are only triggerd on item commands
+| Parameter | Required | Restrictions                    | Purpose                                                                                                                                                                                                                |
+|-----------|----------|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Item`    | yes      | Alphanumeric & underscores only | specifies the topic to subscribe for actuator events and the return topic to publish the current device state / sensor reading. Device state is published as item update. Actuators are only triggerd on item commands |
 
 ### Dictionary of connectors layout
 To configure a openHAB REST connection in a sensor / actuator use following layout:


### PR DESCRIPTION
This PR adds support and documentation for the [2Ch-Triac-HAT](https://www.waveshare.com/wiki/2-CH_TRIAC_HAT) from Waveshare via i2c-bus. The Triac supports continuous dimming on both channels.
The Triac actuator was tested with all connectors.

This will also update the readme's for all connectors so that all tables are easily readable in the source code.