### PR TITLE
add raspi-config switches to install script

### DIFF
--- a/gpio/README.md
+++ b/gpio/README.md
@@ -77,11 +77,14 @@ A polling sensor that reads temperature from a DS18S20 or DS18B20 1-Wire bus sen
 
 ### Dependencies
 
-To enable the 1-Wire interface on your Raspberry Pi, add the following to the bottom of `/boot/config.txt`:
+This sensor communicates via the `1-Wire interface` on your Raspberry Pi.
+To work properly it also need the kernel modules w1-gpio and w1-therm.
+
+To enable the 1-Wire interface run (boot partition must be writable):
 
 ```bash
-# Enable 1-Wire interface on default GPIO4
-dtoverlay=w1-gpio
+cd /srv/sensorReporter
+sudo ./install_dependencies.sh gpio
 ```
 
 To load the `w1-gpio` and `w1-therm` kernel modules, add the following to `/etc/modules`:

--- a/gpio/dependencies.txt
+++ b/gpio/dependencies.txt
@@ -9,3 +9,6 @@ RPI.GPIO
 # required by DhtSensor
 adafruit-blinka
 adafruit-circuitpython-dht
+[raspi-config]
+# required by Ds18x20Sensor
+do_onewire

--- a/i2c/README.md
+++ b/i2c/README.md
@@ -13,18 +13,11 @@ A received command will be sent back on all configured connections to the config
 
 ### Dependencies
 
-This actuator communicates via the i2c interface, therfore the GPIO 2 and 3 should be free and cannot get accessed directly e. g. with a RpiGPIOSensor.
+This actuator communicates via the `i2c interface`, therfore the GPIO 2 and 3 should be free and cannot get accessed directly e. g. with a RpiGPIOSensor.
 The user running sensor_reporter must be in the `i2c` group to have access to the i2c interface.
 Also the library `lib8relay` must be installed to make this actuator work.
 
-To enable the i2c interface open the Raspberry-Pi configuration via:
-
-```bash
-sudo raspi-config
-```
-and choose Interface Options, then <b>I2C Interface</b> and yes.
-
-To install the dependencies run: 
+To install the dependencies run (boot partition must be writable): 
 
 ```bash
 cd /srv/sensorReporter
@@ -94,18 +87,11 @@ However, most dimmable power supplies (e.g. for LEDs) require reverse phase cont
 
 ### Dependencies
 
-This actuator communicates via the i2c interface, therefore the GPIO 2 and 3 should be free and cannot get accessed directly e. g. with a RpiGPIOSensor.
+This actuator communicates via the `i2c interface`, therefore the GPIO 2 and 3 should be free and cannot get accessed directly e. g. with a RpiGPIOSensor.
 The user running sensor_reporter must be in the `i2c` group to have access to the i2c interface.
 Also the library `smbus2` must be installed to make this actuator work.
 
-To enable the i2c interface open the Raspberry-Pi configuration via:
-
-```bash
-sudo raspi-config
-```
-and choose Interface Options, then <b>I2C Interface</b> and yes.
-
-To install the dependencies run:
+To install the dependencies run (boot partition must be writable):
 
 ```bash
 cd /srv/sensorReporter
@@ -199,18 +185,11 @@ A received command will be sent back on all configured connections to the config
 
 ### Dependencies
 
-This actuator communicates via the i2c interface, therefore the GPIO 2 and 3 should be free and cannot get accessed directly e. g. with a RpiGPIOSensor.
+This actuator communicates via the `i2c interface`, therefore the GPIO 2 and 3 should be free and cannot get accessed directly e. g. with a RpiGPIOSensor.
 The user running sensor_reporter must be in the `i2c` group to have access to the i2c interface.
 Also the library `smbus2` must be installed to make this actuator work.
 
-To enable the i2c interface open the Raspberry-Pi configuration via:
-
-```bash
-sudo raspi-config
-```
-and choose Interface Options, then <b>I2C Interface</b> and yes.
-
-To install the dependencies run:
+To install the dependencies run (boot partition must be writable):
 
 ```bash
 cd /srv/sensorReporter

--- a/i2c/dependencies.txt
+++ b/i2c/dependencies.txt
@@ -7,3 +7,6 @@ lib8relay
 smbus2
 # required by adafruit 16ch PWM
 adafruit-circuitpython-pca9685
+[raspi-config]
+# required by EightRelayHAT, TriacDimmer, adafruit 16ch PWM
+do_i2c

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -70,9 +70,10 @@ UNINSTALL_STR='--uninstall'
 # Function install_dep() will install/remove apt, pip dependencies and add/remove groups to the SR_USER
 # Parameters:
 #	KIND		the kind of the dependency, currently supported:
-#				[apt]		install/remove specified dep-packages via 'apt'
-#				[pip]		install/uninstall specified python-packages via 'pip' in the virtual Python envionment
-#				[groups]	add/remove given specified to/from $SR_USER
+#				[apt]			install/remove specified dep-packages via 'apt'
+#				[pip]			install/uninstall specified python-packages via 'pip' in the virtual Python envionment
+#				[groups]		add/remove given specified to/from $SR_USER
+#				[raspi-config]  enables/disables specified raspi-config switches, see: https://www.raspberrypi.com/documentation/computers/configuration.html#raspi-config-cli
 #	DEP			the name of the package/group
 function install_dep()
 {
@@ -112,6 +113,17 @@ function install_dep()
 			echo "=== installing $DEP ==="
 			# don't run as root
 			su -c "bin/python -m pip install \"$DEP\"" "$USER"
+		fi
+	elif [ "$KIND" = '[raspi-config]' ]; then
+		if [ "$LIST_UNINSTALL_DEP" ]; then
+			echo raspi-config switch: "$DEP"
+		elif [ "$UNINSTALL" ]; then
+			echo "=== disabling raspi-config switch $DEP ==="
+			raspi-config nonint "$DEP" 1
+		else
+			echo "=== enabling raspi-config switch $DEP ==="
+			# yes setting the switch to 0 will enable the feature
+			raspi-config nonint "$DEP" 0
 		fi
 	fi
 }
@@ -177,7 +189,7 @@ if [ "$1" = "$UNINSTALL_STR" ]; then
 	LIST_UNINSTALL_DEP=1
 	# save specified folder list
 	PATH_LIST=$2
-	echo "Script runs in uninstall mod!"
+	echo "Script runs in uninstall mode!"
 	echo "The following packages will be removed regardless of their dependencies on other software:"
 else
 	# save specified folder list


### PR DESCRIPTION
This PR allows the install_dependencies script to handle a [raspi-config] section. So the dependecies.txt can contain a  [raspi-config] section and the script will enable given raspi-config nonint switches in install mode and disables them in uninstall mode. 

+add do_i2c switch for i2c actuators
+add do_onewire switch for Ds18x20Sensor
*updated the readmes accordingly

I tested the changes for the i2c actuator PwmHatColorLED. For the one wire sensor, I could only check that the /boot/config.txt file changed as expected.
This PR solves #122 and is ready for merge.