### PR TITLE
implement lgpio-lib for RpiGpioActuator & GpioColorLED

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ This current version is a nearly complete rewrite of the previous version with a
 
 ## Breaking Changes
 
-- RpiGpioSensor pins can only be configured using Broadcom pin numbering (GPIO numbers) - April 2024
+- RpiGpioSensor, RpiGpioActuator and GpioColorLED pins can only be configured using Broadcom pin numbering (GPIO numbers) - April 2024
 - The configuration file is now in YAML syntax instead of a ini file - October 2022
 - Sending a `kill -1` now causes sensor_reporter to reload it's configuration instead of exiting
 - No longer runnable on Python 2, tested with Python 3.7.
@@ -197,7 +197,7 @@ This current version is a nearly complete rewrite of the previous version with a
 
 ## Other changes
 
-- RpiGpioSensor now uses lgpio library (fixes edge detection not working on kernel 6.6)
+- RpiGpioSensor, RpiGpioActuator and GpioColorLED now uses lgpio library (fixes edge detection not working on kernel 6.6)
 - Logs out to standard out in addition to Syslog or log files.
 - Reogranized singal handleing to make it simpler.
 - Moved the polling to a separate class.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ This current version is a nearly complete rewrite of the previous version with a
 
 ## Other changes
 
-- RpiGpioSensor, RpiGpioActuator and GpioColorLED now uses lgpio library (fixes edge detection not working on kernel 6.6)
+- RpiGpioActuator and GpioColorLED now uses lgpio library
+- RpiGpioSensor now uses lgpio library (fixes edge detection not working on kernel 6.6)
 - Logs out to standard out in addition to Syslog or log files.
 - Reogranized singal handleing to make it simpler.
 - Moved the polling to a separate class.

--- a/core/actuator.py
+++ b/core/actuator.py
@@ -17,73 +17,87 @@
 Classes: Actuator
 """
 from abc import ABC, abstractmethod
+from typing import Any, Callable, Optional
 import logging
-from core.utils import set_log_level
+from core import utils
+from core import connection
 
 class Actuator(ABC):
-    """Class from which all actuator capabilities must inherit. Is assumes there
-    is a "Topic" param and automatically registers to subscribe to that topic
-    with all of the passed in connections. A default implementation is provided
-    for all but the on_message method which must be overridden.
+    """ Class from which all actuator capabilities must inherit. Is assumes there
+        is a "Topic" param and automatically registers to subscribe to that topic
+        with all of the passed in connections. A default implementation is provided
+        for all but the on_message method which must be overridden.
     """
 
-    def __init__(self, connections, dev_cfg):
-        """Initializes the Actuator by storing the passed in arguments as data
-        members and registers to subscribe to params("Topic").
+    def __init__(self,
+                 connections:dict[str, connection.Connection],
+                 dev_cfg:dict[str, Any]) -> None:
+        """ Initializes the Actuator by storing the passed in arguments as data
+            members and registers to subscribe to params("Topic").
 
         Arguments:
-        - connections: List of the connections
-        - dev_cfg: dictionary that holds the device specific config
-            "Connections": required, holds the dictionarys with the configured connections
-            will subscribe to the topic and report the status
-            to the return topic if it is specified
+        - connections: Dictionary of connection-instances,
+                       not to be confused with the 'Connections:' section within the actuator config
+        - dev_cfg:  Dictionary that holds the device specific config
+                    "Connections": required, holds the dictionaries with the configured connections
+                    will subscribe to the topic and report the status
+                    to the return topic if it is specified
         Raises:
         - KeyError if "Connections" doesn't exist.
 
         Important Parameters:
         - self.comm: communication dictionary, with information where to publish
-                     contains connection named dictionarys for each connection
+                     contains connection named dictionaries for each connection
         - self.log: The log instance for this device
-        - self.name: device name, usful for log entries
+        - self.name: device name, useful for log entries
         """
         self.log = logging.getLogger(type(self).__name__)
         self.dev_cfg = dev_cfg
         self.connections = connections
-        self.comm = dev_cfg['Connections']
-        #Actuator Name is specified in sensor_reporter.py > creat_device()
-        self.name = dev_cfg.get('Name')
-        set_log_level(dev_cfg, self.log)
+        self.comm:dict[str, Any] = dev_cfg['Connections']
+        # Actuator Name is specified in sensor_reporter.py > creat_device()
+        # dev_cfg.get('Name') should be already a string, to make it clear for mypy use str()
+        self.name = str(dev_cfg.get('Name'))
+        utils.set_log_level(dev_cfg, self.log)
 
         self._register(self.comm, self.on_message)
 
-    def _register(self, comm, handler):
-        """Protected method that registers to the communicator to subscribe to
-        destination and process incoming messages with handler.
+    def _register(self,
+                  comm:dict[str, Any],
+                  handler:Optional[Callable[[str], None]]) -> None:
+        """ Protected method that registers to the communicator to subscribe to
+            destination and process incoming messages with handler.
         """
 
         for (conn, comm_conn) in comm.items():
             self.connections[conn].register(comm_conn, handler)
 
     @abstractmethod
-    def on_message(self, msg):
-        """Abstract method that will get called when a message is received on a
-        registered destination. Implementers should execute the action the
-        Actuator performes.
+    def on_message(self,
+                   msg:str) -> None:
+        """ Abstract method that will get called when a message is received on a
+            registered destination. Implementers should execute the action the
+            Actuator performs.
+
+            Argument 'msg' is the string message which was received from a connection
+                     to trigger a actuator specific action
         """
 
-    def cleanup(self):
-        """Called to give the Actuator a chance to close down and release any
-        resources.
+    def cleanup(self) -> None:
+        """ Called to give the Actuator a chance to close down and release any
+            resources.
         """
 
-    def _publish(self, message, comm):
-        """Protected method that will publish the passed in message to the
-        passed in comm(unicators).
+    def _publish(self,
+                 message:str,
+                 comm:dict[str, Any]) -> None:
+        """ Protected method that will publish the passed in message to the
+            passed in comm(unicators).
 
         Arguments:
         - message:     the message to publish
         - comm:        communication dictionary, with information where to publish
-                       contains connection named dictionarys for each connection,
+                       contains connection named dictionaries for each connection,
                        containing the connection related parameters
         """
         for conn in comm.keys():
@@ -91,7 +105,7 @@ class Actuator(ABC):
             #so we set it to None
             self.connections[conn].publish(message, comm[conn], None)
 
-    def publish_actuator_state(self):
-        """Called to publish the current state of the actuator to the publishers.
-        The default implementation is a pass.
+    def publish_actuator_state(self) -> None:
+        """ Called to publish the current state of the actuator to the publishers.
+            The default implementation is a pass.
         """

--- a/core/actuator.py
+++ b/core/actuator.py
@@ -23,7 +23,7 @@ from core import utils
 from core import connection
 
 class Actuator(ABC):
-    """ Class from which all actuator capabilities must inherit. Is assumes there
+    """ Class from which all actuator capabilities must inherit. It assumes there
         is a "Topic" param and automatically registers to subscribe to that topic
         with all of the passed in connections. A default implementation is provided
         for all but the on_message method which must be overridden.

--- a/core/connection.py
+++ b/core/connection.py
@@ -18,7 +18,8 @@ Classes: Connections
 """
 from abc import ABC, abstractmethod
 import logging
-from core.utils import set_log_level
+# workaround circular import connection <=> utils, import only file but not the method/object
+from core import utils
 
 class Connection(ABC):
     """Parent class that all connections must implement. It provides a default
@@ -38,7 +39,7 @@ class Connection(ABC):
         self.msg_processor = msg_processor
         self.conn_cfg = conn_cfg
         self.registered = {}
-        set_log_level(conn_cfg, self.log)
+        utils.set_log_level(conn_cfg, self.log)
 
     @abstractmethod
     def publish(self, message, comm_conn, output_name=None):

--- a/core/sensor.py
+++ b/core/sensor.py
@@ -19,7 +19,10 @@ Classes: Sensor
 
 from abc import ABC
 import logging
-from core.utils import set_log_level, DEFAULT_SECTION
+from typing import Any, Union, Optional
+# workaround circular import sensor <=> utils, import only file but not the method/object
+from core import utils
+from core import connection
 
 
 class Sensor(ABC):
@@ -27,65 +30,72 @@ class Sensor(ABC):
     publish_state should be overridden.
     """
 
-    def __init__(self, publishers, dev_cfg):
+    def __init__(self,
+                 publishers:dict[str, connection.Connection],
+                 dev_cfg:dict[str, Any]) -> None:
         """
         Sets all the passed in arguments as data members. If params("Poll")
         exists self.poll will be set to that. If not it is initialized to -1.
-        self.last_poll is initialied to None.
+        self.last_poll is initialized to None.
 
         Arguments:
-        - publishers: list of Connection objects to report to.
+        - publishers: Dictionary of connection-instances,
+                      not to be confused with the 'Connections:' section within the actuator config
         - dev_cfg: parameters from the section in the yaml file the sensor is created
         from.
 
         Important Parameters:
         - self.comm: communication dictionary, with information where to publish
-                     contains connection named dictionarys for each connection
+                     contains connection named dictionaries for each connection
         - self.log: The log instance for this device
         - self.poll: The poll interval in seconds
-        - self.name: device name, usful for log entries
+        - self.name: device name, useful for log entries
         """
         self.log = logging.getLogger(type(self).__name__)
         self.publishers = publishers
-        self.comm = dev_cfg['Connections']
+        self.comm:dict[str, Any] = dev_cfg['Connections']
         self.dev_cfg = dev_cfg
         #Sensor Name is specified in sensor_reporter.py > creat_device()
-        self.name = dev_cfg.get('Name')
+        self.name = str(dev_cfg.get('Name'))
         self.poll = float(dev_cfg.get("Poll", -1))
 
         self.last_poll = None
-        set_log_level(dev_cfg, self.log)
+        utils.set_log_level(dev_cfg, self.log)
 
 
-    def _register(self, comm):
+    def _register(self,
+                  comm:dict[str, Any]) -> None:
         """Protected method to register the sensor outputs to a connection
         which supports auto discover
         """
         for (conn, comm_conn) in comm.items():
             self.publishers[conn].register(comm_conn, None)
 
-    def check_state(self):
+    def check_state(self) -> None:
         """Called to check the latest state of sensor and publish it. If not
         overridden it just calls publish_state().
         """
         self.publish_state()
 
-    def publish_state(self):
+    def publish_state(self) -> None:
         """Called to publish the current state to the publishers. The default
         implementation is a pass.
         """
 
-    def _send(self, message, comm, output_name=None):
-        """Sends message the the comm(unicators). Optionally specifie the output_name
+    def _send(self,
+              message:Union[str, dict[str, str]],
+              comm:dict[str, Any],
+              output_name:Optional[str] = None) -> None:
+        """Sends message the the comm(unicators). Optionally specify the output_name
         to set a output channel to publish to.
 
         Arguments:
         - message:     the message to publish as string or dict (generated from get_msg_from_values)
         - comm:        communication dictionary, with information where to publish
-                       contains connection named dictionarys for each connection,
+                       contains connection named dictionaries for each connection,
                        containing the connection related parameters
         - output_name: optional, the output channel to publish the message to,
-                       defines the subdirectory in comm_conn to look for the return topic.
+                       defines the sub-directory in comm_conn to look for the return topic.
                        When defined the output_name must be present
                        in the sensor YAML configuration:
                        Connections:
@@ -94,16 +104,16 @@ class Sensor(ABC):
         """
         #accept regular messages directly
         if not isinstance(message, dict):
-            msg = message
+            msg:str = message
 
         for conn in comm.keys():
             #if message is a value_dict from get_msg_from_values, grab the current conn message
             #use list in default section if conn section is not present
             if isinstance(message, dict):
-                msg = message.get(conn, message[DEFAULT_SECTION])
+                msg = message.get(conn, message[utils.DEFAULT_SECTION])
 
             self.publishers[conn].publish(msg, comm[conn], output_name)
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         """Called when shutting down the sensor, give it a chance to clean up
         and release resources."""

--- a/core/utils.py
+++ b/core/utils.py
@@ -8,6 +8,7 @@ Functions:
 """
 import logging
 import datetime
+import colorsys
 from enum import Enum, auto
 from typing import Any, Union, Optional
 # workaround circular import sensor <=> utils, import only file but not the method/object
@@ -378,3 +379,189 @@ class Debounce():
         if seconds_since_toggle < self.debounce_time:
             return True
         return False
+
+class ColorHSV():
+    ''' Stores HSV color values. Hue can range from 0 (= off) to 360 (= full brightness),
+        Saturation and Value can range from 0 (= off) to 100 (= full brightness).
+        Allows read access to individual values and a dictionary of all RGBW values.
+        Exposed property to set and get color in HSV format
+        e. g. green with full brightness =  '120,100,100'
+    '''
+
+    # Constants
+    C_RED = "Red"
+    C_GREEN = "Green"
+    C_BLUE = "Blue"
+    C_WHITE = "White"
+    C_RGBW_ARRAY = [C_RED, C_GREEN, C_BLUE, C_WHITE]
+    C_HUE = 'Hue'
+    C_SAT = 'Saturation'
+    C_VAL = 'Value'
+
+    def __init__(self,
+                 RGBW_dict:dict[str, int],
+                 use_white_channel:bool) -> None:
+        ''' Initializes colors to a given value (range 0 to 100)
+            Parameters:
+                * RGBW_dict             Dictionary of color : value pairs that define
+                                        the initial value for the colors.
+                                        RGBW_dict = {
+                                            C_RED   : red_value,
+                                            C_GREEN : green_value,
+                                            C_BLUE  : blue_value,
+                                            C_WHITE : white_value
+                                            }
+                                        Range: 0 (= off) to 100 (= full brightness)
+                * use_white_channel     Boolean, if true the 'color_hsv_str' property assumes
+                                        a white LED is present.
+                                        So HSV color 0,0,100 (no saturation) will be
+                                        converted to RGBW {red: 0, green: 0, blue:0, white:100}
+                                        If false: HSV color 0,0,100 will result in RGBW
+                                        {red: 100, green: 100, blue:100, white:0}
+        '''
+        self._hsv = {
+            self.C_HUE : 0,
+            self.C_SAT : 0,
+            self.C_VAL : 0
+            }
+        self.use_white_ch = use_white_channel
+
+        if RGBW_dict.get(self.C_WHITE, 0) != 0:
+            RGBW_dict[self.C_RED] = 0
+            RGBW_dict[self.C_GREEN]= 0
+            RGBW_dict[self.C_BLUE] = 0
+
+        self.rgbw_dict = RGBW_dict
+
+    def __eq__(self,
+               other_obj:object) -> bool:
+        ''' own implementation of compare equality to simplify code using this class
+        '''
+        if not isinstance(other_obj, ColorHSV):
+            # only compare to ColorHSV class
+            return NotImplemented
+        return self._hsv == other_obj.hsv_dict
+
+    @property
+    def rgbw_dict(self) -> dict[str, int]:
+        ''' Get or set color as RGBW dictionary
+            RGBW_dict = {
+                C_RED   : red_value,
+                C_GREEN : green_value,
+                C_BLUE  : blue_value,
+                C_WHITE : white_value
+                        }
+            If colors are not present in the dictionary when writing
+            to this property the value is assumed to be 0
+        '''
+        # create empty RGBW dict
+        rgbw_dict = {}
+        for key in self.C_RGBW_ARRAY:
+            rgbw_dict[key] = 0
+
+        # Check if saturation (hsv_array[1]) equals 0 then set RGB = 0 w = value (hsv_array)
+        if self._hsv[self.C_SAT] == 0 and self.use_white_ch:
+            # set white channel to saturation
+            rgbw_dict[self.C_WHITE] = self._hsv[self.C_VAL]
+        else:
+            # Convert HSV color to RGB color tuple
+            color_rgb = colorsys.hsv_to_rgb(self._hsv[self.C_HUE]/360,
+                                            self._hsv[self.C_SAT]/100,
+                                            self._hsv[self.C_VAL]/100)
+            # Set white channel to 0
+            color_rgbw = color_rgb + (0,)
+            # store converted values
+            for (key, val) in zip(self.C_RGBW_ARRAY, color_rgbw):
+                rgbw_dict[key] = round(val * 100)
+
+        return rgbw_dict
+
+    @rgbw_dict.setter
+    def rgbw_dict(self,
+                  rgbw_dict:dict[str, int]) -> None:
+        # Build HSV color CSV array
+        if rgbw_dict.get(self.C_WHITE, 0) == 0:
+            # If white is not set use RGB values
+            # Normalize RGB values and calculate HSV color
+            hsv_tuple = colorsys.rgb_to_hsv(rgbw_dict.get(self.C_RED, 0)/100,
+                                            rgbw_dict.get(self.C_GREEN, 0)/100,
+                                            rgbw_dict.get(self.C_BLUE, 0)/100)
+            # scale hsv_tuple and build array
+            hsv_array = [hsv_tuple[0] * 360,
+                         hsv_tuple[1] * 100,
+                         hsv_tuple[2] * 100]
+            if hsv_array[1] == 0:
+                # Note: HSV 0,0,x seems to be out of range for openHAB item
+                # and HSV 1,0,0 doesn't work for homie connection using 2,0,x instead
+                hsv_array[0] = 2
+        else:
+            # Build HSV color array for case white color is set
+            # Note: 0,0,x seems to be out of range for openHAB using 1,0,x instead
+            hsv_array = [2,0,rgbw_dict[self.C_WHITE]]
+        # store result as integer to get rid of floating point numbers
+        self._hsv[self.C_HUE] = int(hsv_array[0])
+        self._hsv[self.C_SAT] = int(hsv_array[1])
+        self._hsv[self.C_VAL] = int(hsv_array[2])
+
+    @property
+    def hsv_dict(self) -> dict[str, int]:
+        ''' Get the internal HSV dictionary
+        '''
+        return self._hsv
+
+    @property
+    def color_hsv_str(self) -> str:
+        ''' Get or set the color in HSV format
+            as comma separated value string without spaces: hue,saturation,value
+            E. g. pure red in full brightness = '0,100,100'
+        '''
+        # build hsv_color_str
+        hsv_color_str = ( f'{int(self._hsv[self.C_HUE])},'
+                          f'{int(self._hsv[self.C_SAT])},'
+                          f'{int(self._hsv[self.C_VAL])}' )
+
+        return hsv_color_str
+
+    @color_hsv_str.setter
+    def color_hsv_str(self,
+                      hsv_str:str) -> None:
+        hsv_array = []
+        # We expect a string with 3 values: hue,saturation,value
+        # Split and convert them to integer
+        for val in hsv_str.split(","):
+            hsv_array.append(int(val))
+
+        self._hsv[self.C_HUE] = hsv_array[0]
+        self._hsv[self.C_SAT] = hsv_array[1]
+        self._hsv[self.C_VAL] = hsv_array[2]
+
+    def get_hsv(self,
+                param:str) -> int:
+        ''' Returns the selected 'parameter' as an integer (range 0 to 100/360).
+            Raises an error if the specified parameter is not in the internal HSV color dictionary.
+            Parameter:
+                * param    String, one of "Hue", "Saturation", "Value"
+        '''
+        if param in self._hsv:
+            return self._hsv[param]
+        raise ValueError(f"Function 'get_hsv()' parameter 'param' has unknown value: {param}")
+
+    def set_hsv(self,
+                param:str,
+                value:int) -> None:
+        ''' Sets the selected 'param' as in integer (range 0 to 100/360).
+            Raises an error if the specified param is not in the internal HSV color dictionary.
+            Parameter:
+                * param    String, one of "Hue", "Saturation", "Value"
+        '''
+        if param in self._hsv:
+            if param == self.C_HUE and (value < 0 or value > 360):
+                raise ValueError(f"Function 'set_hsv()' parameter 'value' \
+                                out of range should be 0 to 360 is: {value}")
+            if param != self.C_HUE and (value < 0 or value > 100):
+                raise ValueError(f"Function 'set_hsv()' parameter 'value' \
+                                out of range should be 0 to 100 is: {value}")
+            self._hsv[param] = value
+        else:
+            raise ValueError(f"Function 'set_hsv()' parameter 'param' has unknown value: {param}")
+

--- a/gpio/README.md
+++ b/gpio/README.md
@@ -25,7 +25,7 @@ sudo ./install_dependencies.sh gpio
 | Parameter     | Required | Restrictions                  | Purpose                                                                                                                                                                                    |
 |---------------|----------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `Class`       | X        | `gpio.dht_sensor.DhtSensor`   |                                                                                                                                                                                            |
-| `Connections` | X        | dictionary of connectors      | Defines where to publish the sensor status for each connection. This sensor has 2 outputs, see below. Look at connection readme's for 'Actuator / sensor relevant parameters' for details. |
+| `Connections` | X        | Dictionary of connectors      | Defines where to publish the sensor status for each connection. This sensor has 2 outputs, see below. Look at connection readme's for 'Actuator / sensor relevant parameters' for details. |
 | `Level`       |          | DEBUG, INFO, WARNING, ERROR   | Override the global log level and use another one for this sensor.                                                                                                                         |
 | `Poll`        | X        | Positive number               | Refresh interval for the sensor in seconds.                                                                                                                                                |
 | `Sensor`      | X        | `DHT11`, `DHT22`, or `AM2302` | The type of the sensor.                                                                                                                                                                    |
@@ -102,7 +102,7 @@ Reboot the Raspberry Pi.
 | Parameter     | Required           | Restrictions                        | Purpose                                                                                                                                                     |
 |---------------|--------------------|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `Class`       | X                  | `gpio.ds18x20_sensor.Ds18x20Sensor` |                                                                                                                                                             |
-| `Connections` | X                  | dictionary of connectors            | Defines where to publish the sensor status for each connection.                                                                                             |
+| `Connections` | X                  | Dictionary of connectors            | Defines where to publish the sensor status for each connection.                                                                                             |
 | `Level`       |                    | `DEBUG`, `INFO`, `WARNING`, `ERROR` | Override the global log level and use another one for this sensor.                                                                                          |
 | `Poll`        | X                  | Positive number                     | Refresh interval for the sensor in seconds.                                                                                                                 |
 | `Mac`         | X                  |                                     | Full 1-Wire device address. To list all 1-Wire devices, run `ls /sys/bus/w1/devices`. To read a specific one, run `cat /sys/bus/w1/devices/<Mac>/w1_slave`. |
@@ -161,7 +161,7 @@ Then follow the installation instructions (Prerequisites and Download&Install) a
 | Parameter        | Required | Restrictions                        | Purpose                                                                                                                                                                                                                                   |
 |------------------|----------|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `Class`          | X        | `gpio.rpi_gpio.RpiGpioSensor`       |                                                                                                                                                                                                                                           |
-| `Connections`    | X        | dictionary of connectors            | Defines where to publish the sensor status for each connection. This sensor has 3 outputs, see below. Look at connection readme's for 'Actuator / sensor relevant parameters' for details.                                                |
+| `Connections`    | X        | Dictionary of connectors            | Defines where to publish the sensor status for each connection. This sensor has 3 outputs, see below. Look at connection readme's for 'Actuator / sensor relevant parameters' for details.                                                |
 | `GpioChip`       | X        | Positive integer                    | Sets the GPIO-Chip to use. Use for Raspberry Pi 1 to 4 `GpioChip: 0` and for Raspberry Pi 5 `GpioChip: 4`. To list GPIOs and Chips write in console: `cat /sys/kernel/debug/gpio`                                                         |
 | `Pin`            | X        | GPIO pin                            | Pin to use as sensor input, using the Broadcom pin numbering (GPIO Number).                                                                                                                                                               |
 | `Level`          |          | `DEBUG`, `INFO`, `WARNING`, `ERROR` | Override the global log level and use another one for this sensor.                                                                                                                                                                        |
@@ -175,9 +175,9 @@ For a valid configuration the basic parameters marked as required are necessary,
 
 | Parameter               | Required | Restrictions                  | Purpose                                                                                                                                                                                                                                                                                                                                                                                 |
 |-------------------------|----------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `Values`                |          | list of strings or dictionary | Values to replace the default state message of the `Switch` output (default is OPEN, CLOSED). For details see below.                                                                                                                                                                                                                                                                    |
-| `Short_Press-Threshold` |          | decimal number                | Defines the lower bound of short button press event in seconds and the debounce when using event detection. Debounce will wait for a signal to be stable for half the time specified here. If the duration of the button press was shorter than this value no update will be send. Useful to ignore false detection of button press due to electrical interferences. (default is 0.002) |
-| `Long_Press-Threshold`  |          | decimal number                | Defines the lower bound of long button press event in seconds, if the duration of the button press was shorter a short button event will be triggered. Can be determinded via the sensor-reporter log when set on info level. If not defined all button press events will be treated as short press.                                                                                    |
+| `Values`                |          | List of strings or dictionary | Values to replace the default state message of the `Switch` output (default is OPEN, CLOSED). For details see below.                                                                                                                                                                                                                                                                    |
+| `Short_Press-Threshold` |          | Decimal number                | Defines the lower bound of short button press event in seconds and the debounce when using event detection. Debounce will wait for a signal to be stable for half the time specified here. If the duration of the button press was shorter than this value no update will be send. Useful to ignore false detection of button press due to electrical interferences. (default is 0.002) |
+| `Long_Press-Threshold`  |          | Decimal number                | Defines the lower bound of long button press event in seconds, if the duration of the button press was shorter a short button event will be triggered. Can be determinded via the sensor-reporter log when set on info level. If not defined all button press events will be treated as short press.                                                                                    |
 | `Btn_Pressed_State`     |          | LOW or HIGH                   | Sets the expected input level for short and long button press events. Set it to `LOW` if the input pin is connected to ground while the button is pressed (default is determined via PUD config value: `PUD = UP` will assume `Btn_Pressed_State: LOW`)                                                                                                                                 |
 
 #### Values parameter
@@ -271,7 +271,7 @@ A received command will be sent back on all configured connections to the config
 
 ### Dependencies
 
-Depends on `RPi.GPIO` Python library.
+Depends on `lgpio` Python library.
 The user running sensor_reporter must be in the `gpio` group to have GPIO access.
 
 ```bash
@@ -279,26 +279,31 @@ cd /srv/sensorReporter
 sudo ./install_dependencies.sh gpio
 ```
 
+#### For Debian 11 (bullseye) - Raspberry Pi OS (Legacy)
+
+Older OS (with `ldd --version` < glibc 2.33) need to manually install the `lgpio` Python library.
+If the 'install_dependencies.sh' script was called with the 'gpio' parameter, manual removal of the incompatible lgpio version is required:
+
+```bash
+cd /srv/sensorReporter
+bin/python -m pip uninstall lgpio
+```
+
+Then follow the installation instructions (Prerequisites and Download&Install) at: [https://abyz.me.uk/lg/download.html](https://abyz.me.uk/lg/download.html)
+
 ### Parameters
 
 | Parameter        | Required | Restrictions                    | Purpose                                                                                                                                                                           |
 |------------------|----------|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `Class`          | X        | `gpio.rpi_gpio.RpiGpioActuator` |                                                                                                                                                                                   |
-| `Connections`    | X        | dictionary of connectors        | Defines where to subscribe for messages and where to publish the status for each connection. Look at connection readme's for 'Actuator / sensor relevant parameters' for details. |
-| `Pin`            | X        | IO Pin                          | Pin to use as actuator output, using the pin numbering defined in `PinNumbering` (see below).                                                                                     |
+| `Connections`    | X        | Dictionary of connectors        | Defines where to subscribe for messages and where to publish the status for each connection. Look at connection readme's for 'Actuator / sensor relevant parameters' for details. |
+| `GpioChip`       | X        | Positive integer                | Sets the GPIO-Chip to use. Use for Raspberry Pi 1 to 4 `GpioChip: 0` and for Raspberry Pi 5 `GpioChip: 4`. To list GPIOs and Chips write in console: `cat /sys/kernel/debug/gpio` |
+| `Pin`            | X        | GPIO pin                        | Pin to use as actuator output, using the Broadcom pin numbering (GPIO Number).                                                                                                    |
 | `Level`          |          | DEBUG, INFO, WARNING, ERROR     | Override the global log level and use another one for this sensor.                                                                                                                |
-| `ToggleDebounce` |          | decimal number                  | The interval in seconds during which repeated toggle commands are ignored (default 0.15 seconds)                                                                                  |
-| `InitialState`   |          | ON or OFF                       | Optional, when set to ON the pin's state is initialized to HIGH. Ignores InvertOut (default OFF)                                                                                  |
+| `ToggleDebounce` |          | Decimal number                  | The interval in seconds during which repeated toggle commands are ignored (default 0.15 seconds)                                                                                  |
+| `InitialState`   |          | HIGH / LOW, (ON / OFF)          | Optional, initializes the pin to the given state. Ignores InvertOut. (ON = HIGH, default LOW)                                                                                     |
 | `SimulateButton` |          | Boolean                         | When `True` simulates a button press by setting the pin to HIGH for half a second and then back to LOW. In case of `InitalState` ON it will toggle the other way around.          |
 | `InvertOut`      |          | Boolean                         | Inverts the output when set to `True`. When inverted sending `ON` to the actuator will set the output to LOW, `OFF` will set the output to HIGH.                                  |
-
-### Global parameters
-
-Can only be set for all GPIO devices (RpiGpioSensor and RpiGpioActuator). Global parameters are set in the `DEFAULT` section.
-
-| Parameter      | Required | Restrictions | Purpose                                                                                                                                                                           |
-|----------------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `PinNumbering` |          | BCM or BOARD | Select which numbering to use for the IO Pin's. Use BCM when GPIO numbering is desired. BOARD refers to the pin numbers on the P1 header of the Raspberry Pi board. (default BCM) |
 
 ### Outputs / Inputs
 
@@ -330,6 +335,7 @@ ActuatorGarageDoor:
     Connections:
         openHAB:
             Item: GarageDoorCmd
+    GpioChip: 0
     Pin: 35
     InitialState: ON
     SimulateButton: True
@@ -360,6 +366,7 @@ SensorLightSwitch:
         local:
             ShortButtonPress:
                 StateDest: toggle_garage_light
+    GpioChip: 0
     Pin: 17
     PUD: UP
     EventDetection: BOTH
@@ -372,6 +379,7 @@ ActuatorGarageLight:
             CommandSrc: toggle_garage_light
         openHAB:
             Item: garage_light
+    GpioChip: 0
     Pin: 19
 ```
 
@@ -386,7 +394,7 @@ A received command will be sent back on all configured connections to the config
 
 ### Dependencies
 
-Depends on `RPi.GPIO` Python library.
+Depends on `lgpio` Python library.
 The user running sensor_reporter must be in the `gpio` group to have GPIO access.
 
 ```bash
@@ -394,23 +402,30 @@ cd /srv/sensorReporter
 sudo ./install_dependencies.sh gpio
 ```
 
+#### For Debian 11 (bullseye) - Raspberry Pi OS (Legacy)
+
+Older OS (with `ldd --version` < glibc 2.33) need to manually install the `lgpio` Python library.
+If the 'install_dependencies.sh' script was called with the 'gpio' parameter, manual removal of the incompatible lgpio version is required:
+
+```bash
+cd /srv/sensorReporter
+bin/python -m pip uninstall lgpio
+```
+
+Then follow the installation instructions (Prerequisites and Download&Install) at: [https://abyz.me.uk/lg/download.html](https://abyz.me.uk/lg/download.html)
+
 ### Parameters
 
 | Parameter       | Required | Restrictions                 | Purpose																																														 |
 |-----------------|----------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `Class`         | X        | `gpio.gpio_led.GpioColorLED` |																																																 |
-| `Connections`   | X        | dictionary of connectors     | Defines where to subscribe for messages and where to publish the status for each connection. Look at connection readme's for 'Actuator / sensor relevant parameters' for details.				 |
-| `Pin`           | X        | dictionary of pin's          | Pin to use as PWM output. Use sub parameter `Red`, `Green`, `Blue`, `White`, using the pin numbering defined in `PinNumbering` (see below). It is not necessary to define pin's for all colors. |
+| `Connections`   | X        | Dictionary of connectors     | Defines where to subscribe for messages and where to publish the status for each connection. Look at connection readme's for 'Actuator / sensor relevant parameters' for details.				 |
+| `GpioChip`      | X        | Positive integer             | Sets the GPIO-Chip to use. Use for Raspberry Pi 1 to 4 `GpioChip: 0` and for Raspberry Pi 5 `GpioChip: 4`. To list GPIOs and Chips write in console: `cat /sys/kernel/debug/gpio`              |
+| `Pin`           | X        | Dictionary of GPIO pin's     | Pin to use as PWM output. Use sub parameter `Red`, `Green`, `Blue`, `White`, using the Broadcom pin numbering (GPIO Number). It is not necessary to define pin's for all colors. 				 |
 | `Level`         |          | DEBUG, INFO, WARNING, ERROR  | When provided, sets the logging level for the sensor.																																			 |
-| `InitialState`  |          | dictionary of values 0-100   | Optional, will set the PWM duty cycle for the color (0 = off, 100 = on, full brightness). Use the sub parameter `Red`, `Green`, `Blue`, `White` (default RGBW = 0)							 |
+| `InitialState`  |          | Dictionary of values 0-100   | Optional, will set the PWM duty cycle for the color (0 = off, 100 = on, full brightness). Use the sub parameter `Red`, `Green`, `Blue`, `White` (default RGBW = 0)							 |
 | `InvertOut`     |          | Boolean                      | Use `True` for common anode LED (default setting). Otherwise use `False`																													     |
-| `PWM-Frequency` |			 | number						| Sets the PWM frequency in Hz (default 100 Hz)																																					 |
-
-### Global parameters
-Can only be set for all GPIO devices (RpiGpioSensor, RpiGpioActuator and GpioColorLED). Global parameters are set in the `DEFAULT` section
-| Parameter 	 | Required | Restrictions | Purpose																																										   |
-|----------------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `PinNumbering` | 			| BCM or BOARD | Select which numbering to use for the IO Pin's. Use BCM when GPIO numbering is desired. BOARD refers to the pin numbers on the P1 header of the Raspberry Pi board. (default BCM) |
+| `PWM-Frequency` |			 | Number						| Sets the PWM frequency in Hz (default 100 Hz)																																					 |
 
 ### Outputs / Inputs
 The GpioColorLED has only one output and input.
@@ -434,6 +449,7 @@ Connection_openHAB:
     
 ActuatorRgbLED:
     Class: gpio.gpio_led.GpioColorLED
+    GpioChip: 0
     Pin:
         Red: 5
         Blue: 13

--- a/gpio/README.md
+++ b/gpio/README.md
@@ -389,7 +389,7 @@ Circuit diagram
 
 ## `gpio.gpio_led.GpioColorLED`
 
-Commands 3 to 4 GPIO pins to control a RGB or RGBW LED via software PWM.
+Commands 1, 3 or 4 GPIO pins to control a white, RGB or RGBW LED via software PWM.
 A received command will be sent back on all configured connections to the configured return topic, to keep them up to date.
 
 ### Dependencies
@@ -426,14 +426,22 @@ Then follow the installation instructions (Prerequisites and Download&Install) a
 | `InitialState`  |          | Dictionary of values 0-100   | Optional, will set the PWM duty cycle for the color (0 = off, 100 = on, full brightness). Use the sub parameter `Red`, `Green`, `Blue`, `White` (default RGBW = 0)							 |
 | `InvertOut`     |          | Boolean                      | Use `True` for common anode LED (default setting). Otherwise use `False`																													     |
 | `PWM-Frequency` |			 | Number						| Sets the PWM frequency in Hz (default 100 Hz)																																					 |
+| `ToggleDebounce`|          | Decimal number               | The interval in seconds during which repeated toggle commands are ignored. (default 0.15 seconds)                                                                                              |
 
 ### Outputs / Inputs
 The GpioColorLED has only one output and input.
 The input expects 3 comma separated values as command. 
-The values will set the LED color in HSV color space, e.g. `h,s,v`.
+The values will set the LED color in HSV color space `h,s,v`, e.g. 240,100,100.
 If the white pin is configured and the second value (saturation) = 0 then only the white LED will shine.
+If only the white channel is configured one value (0-100) is sufficient as input.
 The output will replay the LED color state in the same format.
+
+The GpioColorLED also accepts ON, OFF, TOGGLE or a datetime string as a command.
+While ON, OFF will set the brightness to 100% or 0% respectively, TOGGLE and a datetime string will toggle the brightness to the last state.
+
+Can be connected directly to a RpiGpioSensor ShortButtonPress / LongButtonPress output.
 When using with the openHAB connection configure a color item.
+If only the white channel is configured use a dimmer item in openHAB.
 
 ### Example Config
 ```yaml

--- a/gpio/dependencies.txt
+++ b/gpio/dependencies.txt
@@ -4,9 +4,9 @@ libgpiod2
 [groups]
 gpio
 [pip]
-# required by DhtSensor, RpiGpioActuator, GpioColorLED
+# required by DhtSensor
 RPI.GPIO
-# required by RpiGpioSensor
+# required by RpiGpioSensor, RpiGpioActuator, GpioColorLED
 lgpio
 # required by DhtSensor
 adafruit-blinka

--- a/gpio/dependencies.txt
+++ b/gpio/dependencies.txt
@@ -2,14 +2,12 @@
 # required by DhtSensor
 libgpiod2
 [groups]
+# required by RpiGpioSensor, RpiGpioActuator, GpioColorLED
 gpio
 [pip]
-# required by DhtSensor
-RPI.GPIO
 # required by RpiGpioSensor, RpiGpioActuator, GpioColorLED
 lgpio
 # required by DhtSensor
-adafruit-blinka
 adafruit-circuitpython-dht
 [raspi-config]
 # required by Ds18x20Sensor


### PR DESCRIPTION
This PR changes the GPIO library for the RpiGpioActuator & GpioColorLED to lgpio.

*changed RpiGpioActuator & GpioColorLED to use lgpio instead of RPi.GPIO
+added type annotation for RpiGpioActuator, GpioColorLED, core.sensor and core.actuator to allow type checking (e. g. with mypy)
*GpioColorLED modified so it can be used as a single-channel dimmer

Difference to the RPi.GPIO implementation: after exiting sensor_reporter the GPIOs return to the state before sensor_reporter claimed them.
In a later PR I'll remove the ColorHSV class from the i2c.pwm file and use the one in utils.

Tested with Debian 12 (bookworm, kernel 6.6) with mqtt, home and openHab connector. This PR is ready to merge.