### PR TITLE
add connector disconnect/reconnect triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ bin/python sensor_reporter.py sensor_reporter.yml
 (optional) enable & start the service:
 
 4. set service to auto start:  `sudo systemctl enable sensor_reporter.service`
-5. start sensor_reporter:  `sudo sytemctl start sensor_reporter.service`
+5. start sensor_reporter:  `sudo systemctl start sensor_reporter.service`
 
-To reload a modified sensor_reporter.yml use the command:  `sudo sytemctl reload sensor_reporter.service`  
+To reload a modified sensor_reporter.yml use the command:  `sudo systemctl reload sensor_reporter.service`  
 After large changes to the configuration, e. g. sensors/actuators has been removed/added, a restart of the service is recommended.
 
 # Configuration

--- a/core/actuator.py
+++ b/core/actuator.py
@@ -17,10 +17,12 @@
 Classes: Actuator
 """
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Optional, Dict
+from typing import Any, Callable, Optional, Dict, TYPE_CHECKING
 import logging
 from core import utils
-from core import connection
+if TYPE_CHECKING:
+    # Fix circular imports needed for the type checker
+    from core import connection
 
 class Actuator(ABC):
     """ Class from which all actuator capabilities must inherit. It assumes there
@@ -30,7 +32,7 @@ class Actuator(ABC):
     """
 
     def __init__(self,
-                 connections:Dict[str, connection.Connection],
+                 connections:Dict[str, 'connection.Connection'],
                  dev_cfg:Dict[str, Any]) -> None:
         """ Initializes the Actuator by storing the passed in arguments as data
             members and registers to subscribe to params("Topic").

--- a/core/actuator.py
+++ b/core/actuator.py
@@ -17,7 +17,7 @@
 Classes: Actuator
 """
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Dict
 import logging
 from core import utils
 from core import connection
@@ -30,8 +30,8 @@ class Actuator(ABC):
     """
 
     def __init__(self,
-                 connections:dict[str, connection.Connection],
-                 dev_cfg:dict[str, Any]) -> None:
+                 connections:Dict[str, connection.Connection],
+                 dev_cfg:Dict[str, Any]) -> None:
         """ Initializes the Actuator by storing the passed in arguments as data
             members and registers to subscribe to params("Topic").
 
@@ -54,7 +54,7 @@ class Actuator(ABC):
         self.log = logging.getLogger(type(self).__name__)
         self.dev_cfg = dev_cfg
         self.connections = connections
-        self.comm:dict[str, Any] = dev_cfg['Connections']
+        self.comm:Dict[str, Any] = dev_cfg['Connections']
         # Actuator Name is specified in sensor_reporter.py > creat_device()
         # dev_cfg.get('Name') should be already a string, to make it clear for mypy use str()
         self.name = str(dev_cfg.get('Name'))
@@ -68,7 +68,7 @@ class Actuator(ABC):
         utils.verify_connections_layout(self.comm, self.log, self.name, None)
 
     def _register(self,
-                  comm:dict[str, Any],
+                  comm:Dict[str, Any],
                   handler:Optional[Callable[[str], None]]) -> None:
         """ Protected method that registers to the communicator to subscribe to
             destination and process incoming messages with handler.
@@ -95,7 +95,7 @@ class Actuator(ABC):
 
     def _publish(self,
                  message:str,
-                 comm:dict[str, Any]) -> None:
+                 comm:Dict[str, Any]) -> None:
         """ Protected method that will publish the passed in message to the
             passed in comm(unicators).
 

--- a/core/connection.py
+++ b/core/connection.py
@@ -18,7 +18,7 @@ Classes: Connections
 """
 from abc import ABC, abstractmethod
 from enum import Enum, auto
-from typing import Union, Callable, Optional, Any
+from typing import Callable, Optional, Any
 import logging
 # workaround circular import connection <=> utils, import only file but not the method/object
 from core import utils

--- a/core/connection.py
+++ b/core/connection.py
@@ -18,7 +18,7 @@ Classes: Connections
 """
 from abc import ABC, abstractmethod
 from enum import Enum, auto
-from typing import Callable, Optional, Any
+from typing import Callable, Optional, Any, Dict
 import logging
 # workaround circular import connection <=> utils, import only file but not the method/object
 from core import utils
@@ -51,7 +51,7 @@ class Connection(ABC):
 
     def __init__(self,
                  msg_processor:Callable[[str], None],
-                 conn_cfg:dict[str, Any]) -> None:
+                 conn_cfg:Dict[str, Any]) -> None:
         """ Stores the passed in arguments as data members.
 
         Arguments:
@@ -63,16 +63,16 @@ class Connection(ABC):
         self.log = logging.getLogger(type(self).__name__)
         self.msg_processor = msg_processor
         self.conn_cfg = conn_cfg
-        self.registered:dict[str, Callable[[str], None]] = {}
+        self.registered:Dict[str, Callable[[str], None]] = {}
         self.state = ConnState.INIT
-        self.value_send_buff:dict[int, Any] = {}
-        self.online_offline_act:dict[int, Any] = {}
+        self.value_send_buff:Dict[int, Any] = {}
+        self.online_offline_act:Dict[int, Any] = {}
         utils.set_log_level(conn_cfg, self.log)
 
     @abstractmethod
     def publish(self,
                 message:str,
-                comm_conn:dict[str, Any],
+                comm_conn:Dict[str, Any],
                 output_name:Optional[str] = None) -> None:
         """ Abstract method that must be overridden. When called, send the passed
             in message to the passed in comm(unication)_conn(ection) related dictionary.
@@ -93,7 +93,7 @@ class Connection(ABC):
 
     def prepare_publish(self,
                         message:str,
-                        comm_conn:dict[str, Any],
+                        comm_conn:Dict[str, Any],
                         output_name:Optional[str] = None) -> None:
         """ Internal method to store messages in case the connection is offline.
             If a sensor doesn't has 'ConnectionOnReconnect' configured, send messages
@@ -183,7 +183,7 @@ class Connection(ABC):
 
     @abstractmethod
     def register(self,
-                 comm_conn:dict[str, Any],
+                 comm_conn:Dict[str, Any],
                  handler:Optional[Callable[[str], None]]) -> None:
         """ Set up the passed in handler to be called for any message on the
             destination.
@@ -205,7 +205,7 @@ class Connection(ABC):
         #    self.registered[comm_conn['CommandSrc']] = handler
 
     def prepare_register(self,
-                         comm_conn:dict[str, Any],
+                         comm_conn:Dict[str, Any],
                          handler:Optional[Callable[[str], None]]) -> None:
         """ Internal method to register connection related actuator actions
             which get triggered when the connection calls conn_went_offline() or

--- a/core/sensor.py
+++ b/core/sensor.py
@@ -19,10 +19,11 @@ Classes: Sensor
 
 from abc import ABC
 import logging
-from typing import Any, Union, Optional, Dict
-# workaround circular import sensor <=> utils, import only file but not the method/object
+from typing import Any, Union, Optional, Dict, TYPE_CHECKING
 from core import utils
-from core import connection
+if TYPE_CHECKING:
+    # Fix circular imports needed for the type checker
+    from core import connection
 
 
 class Sensor(ABC):
@@ -31,7 +32,7 @@ class Sensor(ABC):
     """
 
     def __init__(self,
-                 publishers:Dict[str, connection.Connection],
+                 publishers:Dict[str, 'connection.Connection'],
                  dev_cfg:Dict[str, Any]) -> None:
         """
         Sets all the passed in arguments as data members. If params("Poll")
@@ -59,7 +60,7 @@ class Sensor(ABC):
         self.name = str(dev_cfg.get('Name'))
         self.poll = float(dev_cfg.get("Poll", -1))
 
-        self.last_poll = None
+        self.last_poll:Optional[float] = None
         utils.set_log_level(dev_cfg, self.log)
 
 

--- a/core/sensor.py
+++ b/core/sensor.py
@@ -19,7 +19,7 @@ Classes: Sensor
 
 from abc import ABC
 import logging
-from typing import Any, Union, Optional
+from typing import Any, Union, Optional, Dict
 # workaround circular import sensor <=> utils, import only file but not the method/object
 from core import utils
 from core import connection
@@ -31,8 +31,8 @@ class Sensor(ABC):
     """
 
     def __init__(self,
-                 publishers:dict[str, connection.Connection],
-                 dev_cfg:dict[str, Any]) -> None:
+                 publishers:Dict[str, connection.Connection],
+                 dev_cfg:Dict[str, Any]) -> None:
         """
         Sets all the passed in arguments as data members. If params("Poll")
         exists self.poll will be set to that. If not it is initialized to -1.
@@ -53,7 +53,7 @@ class Sensor(ABC):
         """
         self.log = logging.getLogger(type(self).__name__)
         self.publishers = publishers
-        self.comm:dict[str, Any] = dev_cfg['Connections']
+        self.comm:Dict[str, Any] = dev_cfg['Connections']
         self.dev_cfg = dev_cfg
         #Sensor Name is specified in sensor_reporter.py > creat_device()
         self.name = str(dev_cfg.get('Name'))
@@ -64,7 +64,7 @@ class Sensor(ABC):
 
 
     def _register(self,
-                  comm:dict[str, Any]) -> None:
+                  comm:Dict[str, Any]) -> None:
         """Protected method to register the sensor outputs to a connection
         which supports auto discover
         """
@@ -83,8 +83,8 @@ class Sensor(ABC):
         """
 
     def _send(self,
-              message:Union[str, dict[str, str]],
-              comm:dict[str, Any],
+              message:Union[str, Dict[str, str]],
+              comm:Dict[str, Any],
               output_name:Optional[str] = None) -> None:
         """Sends message the the comm(unicators). Optionally specify the output_name
         to set a output channel to publish to.

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,19 +1,38 @@
-"""Utility functions of general use.
+""" Utility functions of general use.
+
+Enumerations:
+    - ChanConst    : Constants used by configure_device_channel and homie_conn
+    - ChanType     : Datatypes supported by configure_device_channel
 
 Functions:
-    - set_log_level: Sets the logging level on the passed in logger to the level
-    equivalent to the passed "Level" property in params.
-    - issage: returns False if the passed in ag contains unsafe characters to use
-    on the command line.
+    - set_log_level                        : Sets the logging level on the passed in logger
+                                             to the level equivalent to the
+                                             passed "Level" property in params.
+    - issafe                               : returns False if the passed in arg
+                                             contains unsafe characters to use
+                                             on the command line.
+    - parse_values                         : Parses the values parameter of a device
+    - get_msg_from_value                   : Get device state for reach connection
+    - get_sequential_params                : Creates values-list from sequentially named parameters
+    - get_dict_of_sequential_param__output : Create dict of sequentially named parameters
+    - is_toggle_cmd                        : Returns true it the input a toggle command
+    - spread_default_parameters            : Populates DEFAULT section to every device config
+    - verify_connections_layout            : Checks the Connections section in the yml config
+    - configure_device_channel             : Setup devices input/outputs to work with auto-discovery
+
+Classes:
+    - Debounce    : Offers methods to debounce received messages
+    - ColorHSV    : Stores Color value in HSV format and offers conversion to RGBW
 """
 import logging
 import datetime
 import colorsys
 from enum import Enum, auto
-from typing import Any, Union, Optional, Dict, List
-# workaround circular import sensor <=> utils, import only file but not the method/object
-from core import sensor
+from typing import Any, Optional, Dict, List, TYPE_CHECKING
 from core import connection
+if TYPE_CHECKING:
+    # Fix circular imports needed for the type checker
+    from core import sensor
 
 DEFAULT_SECTION = "DEFAULT"
 # Constants for auto discover connections:
@@ -26,8 +45,8 @@ CONF_ON_RECONNECT = 'ConnectionOnReconnect'
 CONF_SCHEDULER = 'ConnectionEnabledSchedule'
 
 class ChanConst():
-    """Constants used by configure_device_channel and homie_conn
-    to define channel properties
+    """ Constants used by configure_device_channel and homie_conn
+        to define channel properties
     """
     DATATYPE = "Type"
     NAME = "FullName"
@@ -36,7 +55,7 @@ class ChanConst():
     FORMAT = "FormatOf"
 
 class ChanType(Enum):
-    """Datatypes supported by configure_device_channel
+    """ Datatypes supported by configure_device_channel
     """
     INTEGER = auto()
     FLOAT = auto()
@@ -47,10 +66,10 @@ class ChanType(Enum):
 
 def set_log_level(params:Dict[str, Any],
                   logger:logging.Logger) -> None:
-    """Expects a params with a Level property. If there is no property the
-    default level of INFO is used. Supports all the standard Python logging
-    levels. Sets the level of the passed in logger based on the params Level
-    property.
+    """ Expects a params with a Level property. If there is no property the
+        default level of INFO is used. Supports all the standard Python logging
+        levels. Sets the level of the passed in logger based on the params Level
+        property.
     """
     level = params.get("Level")
 
@@ -66,18 +85,18 @@ def set_log_level(params:Dict[str, Any],
     if level:
         logger.setLevel(levels.get(level, logging.NOTSET))
 
-def issafe(arg):
-    """Returns False if arg contains ';' or '|'."""
+def issafe(arg:str) -> bool:
+    """ Returns False if arg contains ';' or '|'. """
     return arg.find(';') == -1 and arg.find('|') == -1
 
-def parse_values(caller:sensor.Sensor,
+def parse_values(caller:'sensor.Sensor',
                  connections:Dict[str, Any],
                  defaults:List[str]) -> Dict[str, List[str]]:
-    """Parses the Values parameter which should be either
-    a two string values formated as a list or
-    a dictionary with connection sections containing
-    a string list of two items
-    Used to override ON/OFF type messages.
+    """ Parses the Values parameter which should be either
+        a two string values formated as a list or
+        a dictionary with connection sections containing
+        a string list of two items
+        Used to override ON/OFF type messages.
 
     Expects:
     - caller: the object of the calling device,
@@ -90,7 +109,7 @@ def parse_values(caller:sensor.Sensor,
 
     Returns: a dict containing the configured value pairs for each connection
     """
-    values:Union[List[str],Dict[str,List[str]]] = caller.dev_cfg.get('Values', defaults)
+    values = caller.dev_cfg.get('Values', defaults)
     # warn if format is not supported
     if not isinstance(values, (list, dict)):
         values = defaults
@@ -141,9 +160,9 @@ def parse_values(caller:sensor.Sensor,
 
 def get_msg_from_values(values:Dict[str, List[str]],
                         state_on:bool) -> Dict[str, str]:
-    """For sensors which implement custom values to send on state change,
-    this function will generate the msg dict to push to self._send()
-    so every connection will get the corresponding values
+    """ For sensors which implement custom values to send on state change,
+        this function will generate the msg dict to push to self._send()
+        so every connection will get the corresponding values
 
     Expects:
     - values: the value_dict which was returned by parse_values
@@ -162,8 +181,10 @@ def get_msg_from_values(values:Dict[str, List[str]],
 
     return result
 
-def get_sequential_params(dev_cfg, name):
-    """creates a list of values from sequentially named parameters.
+def get_sequential_params(dev_cfg:Dict[str, Any],
+                          name:str) -> List[str]:
+    """ Creates a list of values from sequentially named parameters.
+        Used to create a dictionary in get_dict_of_sequential_param__output.
 
     Arguments:
     - dev_cfg: device configuration
@@ -180,9 +201,11 @@ def get_sequential_params(dev_cfg, name):
             done = True
     return values
 
-def get_dict_of_sequential_param__output(dev_cfg, name, output_name):
-    """Returns a dict of sequentially named parameters and
-    Output names generated acordingly
+def get_dict_of_sequential_param__output(dev_cfg:Dict[str, Any],
+                                         name:str,
+                                         output_name:str) -> Dict[str, Any]:
+    """ Returns a dict of sequentially named parameters and
+        Output names generated accordingly
 
     Arguments:
     - dev_cfg: device configuration
@@ -197,8 +220,8 @@ def get_dict_of_sequential_param__output(dev_cfg, name, output_name):
     return dict(zip(one, two))
 
 def is_toggle_cmd(msg:str) -> bool:
-    """Returns true it the input (msg) is equal
-    to the string "TOGGLE" or is a ISO 8601 formatted date time
+    """ Returns true it the input (msg) is equal
+        to the string "TOGGLE" or is a ISO 8601 formatted date time
     """
     is_toggle = msg == "TOGGLE"
     # datetime from sensor_reporter RpiGpioSensor (e.g. 2021-10-24T16:23:41.500792)
@@ -207,11 +230,12 @@ def is_toggle_cmd(msg:str) -> bool:
     is_dt_timezone = len(msg) == 31 and msg[10] == "T"
     return is_toggle or is_dt or is_dt_timezone
 
-def spread_default_parameters(config, dev_cfg):
-    """takes parameters from the DEFAULT section
-    and spread them to the dev_cfg if not present already
+def spread_default_parameters(config:Dict[str, Any],
+                              dev_cfg:Dict[str, Any]) -> None:
+    """ Takes parameters from the DEFAULT section
+        and spread them to the dev_cfg if not present already
 
-    config: the compleat configuration
+    config: the complete configuration
     dev_cfg: the device specific configuration
     """
     def_cfg = config.get('DEFAULT')
@@ -369,13 +393,13 @@ def configure_device_channel(comm:Dict[str, Any], *,
                 sub[ChanConst.SETTABLE] = True
 
 class Debounce():
-    """ Checks the time difference between two  sequential events
+    """ Checks the time difference between two sequential events
         and checks if the debounce time is already over
     """
 
     def __init__(self, dev_cfg:Dict[str, Any],
                  default_debounce_time:float) -> None:
-        """Init and read device configuration
+        """ Init and read device configuration
 
             Parameters:
             - "dev_cfg"                  : 'dev_cfg' instance of the calling sensor / actuator

--- a/core/utils.py
+++ b/core/utils.py
@@ -23,7 +23,7 @@ IN = "$in"
 # connection sub directory constants
 CONF_ON_DISCONNECT = 'ConnectionOnDisconnect'
 CONF_ON_RECONNECT = 'ConnectionOnReconnect'
-CONF_SCHEDULER = 'Scheduler'
+CONF_SCHEDULER = 'ConnectionEnabledSchedule'
 
 class ChanConst():
     """Constants used by configure_device_channel and homie_conn

--- a/core/utils.py
+++ b/core/utils.py
@@ -10,7 +10,7 @@ import logging
 import datetime
 import colorsys
 from enum import Enum, auto
-from typing import Any, Union, Optional
+from typing import Any, Union, Optional, Dict, List
 # workaround circular import sensor <=> utils, import only file but not the method/object
 from core import sensor
 from core import connection
@@ -45,7 +45,7 @@ class ChanType(Enum):
     ENUM = auto()
     COLOR = auto()
 
-def set_log_level(params:dict[str, Any],
+def set_log_level(params:Dict[str, Any],
                   logger:logging.Logger) -> None:
     """Expects a params with a Level property. If there is no property the
     default level of INFO is used. Supports all the standard Python logging
@@ -71,8 +71,8 @@ def issafe(arg):
     return arg.find(';') == -1 and arg.find('|') == -1
 
 def parse_values(caller:sensor.Sensor,
-                 connections:dict[str, Any],
-                 defaults:list[str]) -> dict[str, list[str]]:
+                 connections:Dict[str, Any],
+                 defaults:List[str]) -> Dict[str, List[str]]:
     """Parses the Values parameter which should be either
     a two string values formated as a list or
     a dictionary with connection sections containing
@@ -90,7 +90,7 @@ def parse_values(caller:sensor.Sensor,
 
     Returns: a dict containing the configured value pairs for each connection
     """
-    values:Union[list[str],dict[str,list[str]]] = caller.dev_cfg.get('Values', defaults)
+    values:Union[List[str],Dict[str,List[str]]] = caller.dev_cfg.get('Values', defaults)
     # warn if format is not supported
     if not isinstance(values, (list, dict)):
         values = defaults
@@ -98,7 +98,7 @@ def parse_values(caller:sensor.Sensor,
                            " Expected dictionary of connection names containing a list."
                            " Using default values instead: %s", caller.name, defaults)
 
-    value_dict:dict[str, list[str]] = {}
+    value_dict:Dict[str, List[str]] = {}
     if isinstance(values, dict):
         value_dict = values
 
@@ -139,8 +139,8 @@ def parse_values(caller:sensor.Sensor,
     # at this point value_dict contains only valid connections and lists of strings
     return value_dict
 
-def get_msg_from_values(values:dict[str, list[str]],
-                        state_on:bool) -> dict[str, str]:
+def get_msg_from_values(values:Dict[str, List[str]],
+                        state_on:bool) -> Dict[str, str]:
     """For sensors which implement custom values to send on state change,
     this function will generate the msg dict to push to self._send()
     so every connection will get the corresponding values
@@ -222,10 +222,10 @@ def spread_default_parameters(config, dev_cfg):
         if key not in dev_cfg:
             dev_cfg[key] = value
 
-def verify_connections_layout(comm:dict[str, Any],
+def verify_connections_layout(comm:Dict[str, Any],
                               log:logging.Logger,
                               name:str,
-                              outputs:Optional[list[str]] = None) -> None:
+                              outputs:Optional[List[str]] = None) -> None:
     """
     Use this method at the end of the sensor initialization
     before calling configure_device_channel().
@@ -277,7 +277,7 @@ def verify_connections_layout(comm:dict[str, Any],
                             ' Valid outputs are: %s', name, key, outputs)
 
 
-def configure_device_channel(comm:dict[str, Any], *,
+def configure_device_channel(comm:Dict[str, Any], *,
                             is_output:bool,
                             output_name:Optional[str] = None,
                             datatype:ChanType = ChanType.STRING,
@@ -373,7 +373,7 @@ class Debounce():
         and checks if the debounce time is already over
     """
 
-    def __init__(self, dev_cfg:dict[str, Any],
+    def __init__(self, dev_cfg:Dict[str, Any],
                  default_debounce_time:float) -> None:
         """Init and read device configuration
 
@@ -425,7 +425,7 @@ class ColorHSV():
     C_VAL = 'Value'
 
     def __init__(self,
-                 RGBW_dict:dict[str, int],
+                 RGBW_dict:Dict[str, int],
                  use_white_channel:bool) -> None:
         ''' Initializes colors to a given value (range 0 to 100)
             Parameters:
@@ -469,7 +469,7 @@ class ColorHSV():
         return self._hsv == other_obj.hsv_dict
 
     @property
-    def rgbw_dict(self) -> dict[str, int]:
+    def rgbw_dict(self) -> Dict[str, int]:
         ''' Get or set color as RGBW dictionary
             RGBW_dict = {
                 C_RED   : red_value,
@@ -504,7 +504,7 @@ class ColorHSV():
 
     @rgbw_dict.setter
     def rgbw_dict(self,
-                  rgbw_dict:dict[str, int]) -> None:
+                  rgbw_dict:Dict[str, int]) -> None:
         # Build HSV color CSV array
         if rgbw_dict.get(self.C_WHITE, 0) == 0:
             # If white is not set use RGB values
@@ -530,7 +530,7 @@ class ColorHSV():
         self._hsv[self.C_VAL] = int(hsv_array[2])
 
     @property
-    def hsv_dict(self) -> dict[str, int]:
+    def hsv_dict(self) -> Dict[str, int]:
         ''' Get the internal HSV dictionary
         '''
         return self._hsv

--- a/gpio/gpio_led.py
+++ b/gpio/gpio_led.py
@@ -16,7 +16,7 @@
 Classes:
     - RpiGpioColourLED: Sets PWM for defined GPIOS
 """
-from typing import Any
+from typing import Any, Dict
 from types import SimpleNamespace
 from copy import deepcopy
 import yaml
@@ -31,8 +31,8 @@ class GpioColorLED(Actuator):
     """
 
     def __init__(self,
-                 connections:dict[str, connection.Connection],
-                 dev_cfg:dict[str, Any]) -> None:
+                 connections:Dict[str, connection.Connection],
+                 dev_cfg:Dict[str, Any]) -> None:
         """Initializes the GPIO subsystem and sets the pin to
         software PWM. Initialized the PWM duty cycle
         to the configured value.
@@ -65,7 +65,7 @@ class GpioColorLED(Actuator):
                            "Make sure the chip number is correct. Error Message: %s",
                            self.name, gpio_chip,err)
         # get pin config
-        dev_cfg_pin:dict[str, int] = dev_cfg["Pin"]
+        dev_cfg_pin:Dict[str, int] = dev_cfg["Pin"]
         self.pin = {}
         for color in utils.ColorHSV.C_RGBW_ARRAY:
             pin_no:int = dev_cfg_pin.get(color, 0)
@@ -74,7 +74,7 @@ class GpioColorLED(Actuator):
                 self.pin[color] = pin_no
 
         # get initial values (optional Parameter)
-        dev_cfg_init_state:dict[str, int] = dev_cfg.get("InitialState", {})
+        dev_cfg_init_state:Dict[str, int] = dev_cfg.get("InitialState", {})
         if not isinstance(dev_cfg_init_state, dict):
             # debug: GPIO-Actuator Property "InitialState" might be in the DEFAULT section
             #        If this is the case and no local "InitialState" is configured

--- a/gpio/gpio_led.py
+++ b/gpio/gpio_led.py
@@ -16,14 +16,16 @@
 Classes:
     - RpiGpioColourLED: Sets PWM for defined GPIOS
 """
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
 from types import SimpleNamespace
 from copy import deepcopy
 import yaml
 import lgpio            # https://abyz.me.uk/lg/py_lgpio.html
 from core.actuator import Actuator
 from core import utils
-from core import connection
+if TYPE_CHECKING:
+    # Fix circular imports needed for the type checker
+    from core import connection
 
 class GpioColorLED(Actuator):
     """Uses Rpi_GPIO software PWM to control color LED's
@@ -31,7 +33,7 @@ class GpioColorLED(Actuator):
     """
 
     def __init__(self,
-                 connections:Dict[str, connection.Connection],
+                 connections:Dict[str, 'connection.Connection'],
                  dev_cfg:Dict[str, Any]) -> None:
         """Initializes the GPIO subsystem and sets the pin to
         software PWM. Initialized the PWM duty cycle
@@ -74,7 +76,7 @@ class GpioColorLED(Actuator):
                 self.pin[color] = pin_no
 
         # get initial values (optional Parameter)
-        dev_cfg_init_state:Dict[str, int] = dev_cfg.get("InitialState", {})
+        dev_cfg_init_state = dev_cfg.get("InitialState", {})
         if not isinstance(dev_cfg_init_state, dict):
             # debug: GPIO-Actuator Property "InitialState" might be in the DEFAULT section
             #        If this is the case and no local "InitialState" is configured

--- a/gpio/rpi_gpio.py
+++ b/gpio/rpi_gpio.py
@@ -20,14 +20,16 @@ Classes:
 from time import sleep
 from distutils.util import strtobool
 from logging import Logger
-from typing import Any, Optional, Union, Dict
+from typing import Any, Optional, Union, Dict, TYPE_CHECKING
 import datetime
 import yaml
 import lgpio            # https://abyz.me.uk/lg/py_lgpio.html
 from core.sensor import Sensor
 from core.actuator import Actuator
 from core import utils
-from core import connection
+if TYPE_CHECKING:
+    # Fix circular imports needed for the type checker
+    from core import connection
 
 # connection dict constants
 OUT_SWITCH = "Switch"
@@ -58,7 +60,7 @@ class RpiGpioSensor(Sensor):
     """Publishes the current state of a configured GPIO pin."""
 
     def __init__(self,
-                 publishers:Dict[str, connection.Connection],
+                 publishers:Dict[str, 'connection.Connection'],
                  dev_cfg:Dict[str, Any]) -> None:
         """ Initializes the connection to the GPIO pin and if "EventDetection"
             if defined and valid, will subscribe for events. If missing, than it
@@ -296,7 +298,7 @@ class RpiGpioActuator(Actuator):
     """
 
     def __init__(self,
-                 connections:Dict[str, connection.Connection],
+                 connections:Dict[str, 'connection.Connection'],
                  dev_cfg:Dict[str, Any]) -> None:
         """ Initializes the GPIO subsystem and sets the pin to the InitialState.
             If InitialState is not provided in params it defaults to lgpio.HIGH.

--- a/gpio/rpi_gpio.py
+++ b/gpio/rpi_gpio.py
@@ -20,7 +20,7 @@ Classes:
 from time import sleep
 from distutils.util import strtobool
 from logging import Logger
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, Dict
 import datetime
 import yaml
 import lgpio            # https://abyz.me.uk/lg/py_lgpio.html
@@ -58,8 +58,8 @@ class RpiGpioSensor(Sensor):
     """Publishes the current state of a configured GPIO pin."""
 
     def __init__(self,
-                 publishers:dict[str, connection.Connection],
-                 dev_cfg:dict[str, Any]) -> None:
+                 publishers:Dict[str, connection.Connection],
+                 dev_cfg:Dict[str, Any]) -> None:
         """ Initializes the connection to the GPIO pin and if "EventDetection"
             if defined and valid, will subscribe for events. If missing, than it
             requires the "Poll" parameter be defined and > 0. By default it will
@@ -100,7 +100,7 @@ class RpiGpioSensor(Sensor):
         # Set up event detection.
         try:
             event_detection:str = dev_cfg["EventDetection"]
-            event_map:dict[str, int] = {"RISING": lgpio.RISING_EDGE,
+            event_map:Dict[str, int] = {"RISING": lgpio.RISING_EDGE,
                                         "FALLING": lgpio.FALLING_EDGE,
                                         "BOTH": lgpio.BOTH_EDGES}
             if event_detection not in event_map:
@@ -226,7 +226,7 @@ class RpiGpioSensor(Sensor):
 class ButtonPressCfg():
     """ Stores all button related parameters """
     def __init__(self,
-                 dev_cfg:dict[str, Any],
+                 dev_cfg:Dict[str, Any],
                  caller:RpiGpioSensor) -> None:
         """ Read optional button press  related parameters from the config
 
@@ -296,8 +296,8 @@ class RpiGpioActuator(Actuator):
     """
 
     def __init__(self,
-                 connections:dict[str, connection.Connection],
-                 dev_cfg:dict[str, Any]) -> None:
+                 connections:Dict[str, connection.Connection],
+                 dev_cfg:Dict[str, Any]) -> None:
         """ Initializes the GPIO subsystem and sets the pin to the InitialState.
             If InitialState is not provided in params it defaults to lgpio.HIGH.
             If "SimulateButton" is defined on any message will result in the pin

--- a/local/local_conn.py
+++ b/local/local_conn.py
@@ -17,7 +17,7 @@
 Classes:
     - LocalConnection: allows sensors to call local actuators.
 """
-from typing import Callable, Optional, Any
+from typing import Callable, Optional, Any, Dict
 from core.connection import Connection
 from core.utils import is_toggle_cmd
 
@@ -43,7 +43,7 @@ class LocalConnection(Connection):
 
     def __init__(self,
                  msg_processor:Callable[[str], None],
-                 conn_cfg:dict[str, Any]) -> None:
+                 conn_cfg:Dict[str, Any]) -> None:
         """ Initializes a local connection. Supports a few simple comparisons
             which can cause the incoming message to be translated to ON/OFF.
 
@@ -85,7 +85,7 @@ class LocalConnection(Connection):
 
     def publish(self,
                 message:str,
-                comm_conn:dict[str, Any],
+                comm_conn:Dict[str, Any],
                 output_name:Optional[str] = None) -> None:
         """ Send the message or, if defined, translate the message to ON or OFF.
 
@@ -135,7 +135,7 @@ class LocalConnection(Connection):
             self.log.debug("There is no handler registered for %s", destination)
 
     def register(self,
-                 comm_conn:dict[str, Any],
+                 comm_conn:Dict[str, Any],
                  handler:Optional[Callable[[str], None]]) -> None:
         """ Set up the passed in handler to be called for any message on the
             destination.

--- a/local/local_conn.py
+++ b/local/local_conn.py
@@ -11,24 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""A special connection to have a sensor activate an actuator that is part of
-this instance of sensor_reporter.
+""" A special connection to have a sensor activate an actuator that is part of
+    this instance of sensor_reporter.
 
 Classes:
     - LocalConnection: allows sensors to call local actuators.
 """
+from typing import Callable, Optional, Any
 from core.connection import Connection
 from core.utils import is_toggle_cmd
 
 class LocalConnection(Connection):
-    """A special connection that can link Sensors and Actuators to other
-    Actuators. One of three optional parameters can be provided:
-    "OnEq": if message equal to this parameter is received publish "ON", works
-    with String messages
-    "OnGT": if the message is greater than this value, publsih "ON", only works
-    with messages that can be parsed to float.
-    "OnLT": if the message is less than this value, publish "ON", only works
-    with messages that can be parsed to float.
+    """ A special connection that can link Sensors and Actuators to other
+        Actuators. One of three optional parameters can be provided:
+        "OnEq": if message equal to this parameter is received publish "ON", works
+                with String messages
+        "OnGT": if the message is greater than this value, publish "ON", only works
+                with messages that can be parsed to float.
+        "OnLT": if the message is less than this value, publish "ON", only works
+                with messages that can be parsed to float.
 
     If none of the optional parameters are present, the message is passes as is.
     All messages that don't match the comparison results in "OFF". If more than
@@ -40,9 +41,11 @@ class LocalConnection(Connection):
     actuator to use this Connection.
     """
 
-    def __init__(self, msg_processor, conn_cfg):
-        """Initializes a local connection. Supports a few simple comparisons
-        which can cause the incoming message to be translated to ON/OFF.
+    def __init__(self,
+                 msg_processor:Callable[[str], None],
+                 conn_cfg:dict[str, Any]) -> None:
+        """ Initializes a local connection. Supports a few simple comparisons
+            which can cause the incoming message to be translated to ON/OFF.
 
         conn_cfg:
             - "OnEq": any message that matches will be converted to "ON" and all
@@ -80,15 +83,18 @@ class LocalConnection(Connection):
         except KeyError:
             pass
 
-    def publish(self, message, comm_conn, output_name=None):
-        """Send the message or, if defined, translate the message to ON or OFF.
+    def publish(self,
+                message:str,
+                comm_conn:dict[str, Any],
+                output_name:Optional[str] = None) -> None:
+        """ Send the message or, if defined, translate the message to ON or OFF.
 
         Arguments:
         - message:     the message to process / publish
         - comm_conn:   dictionary containing only the parameters for the called connection,
                        e. g. information where to publish
         - output_name: optional, the output channel to publish the message to,
-                       defines the subdirectory in comm_conn to look for the return topic.
+                       defines the sub-directory in comm_conn to look for the return topic.
                        When defined the output_name must be present
                        in the sensor YAML configuration:
                        Connections:
@@ -128,9 +134,11 @@ class LocalConnection(Connection):
         else:
             self.log.debug("There is no handler registered for %s", destination)
 
-    def register(self, comm_conn, handler):
-        """Set up the passed in handler to be called for any message on the
-        destination.
+    def register(self,
+                 comm_conn:dict[str, Any],
+                 handler:Optional[Callable[[str], None]]) -> None:
+        """ Set up the passed in handler to be called for any message on the
+            destination.
 
         Arguments:
             - comm_conn: the dictionary containing the connection related parameters

--- a/mqtt/README.md
+++ b/mqtt/README.md
@@ -34,7 +34,7 @@ sudo ./install_dependencies.sh mqtt
 | `RootTopic`   | X        | Valid MQTT topic, no wild cards | Serves as the root topic for all the messages published. For example, if an RpiGpioSensor has a destination "back-door", the actual topic published to will be `<RootTopic>/back-door`.              |
 | `TLS`         |          | Boolean                         | If set to `True`, will use TLS encryption in the connection to the MQTT broker.                                                                                                                      |
 | `CAcert`      |          | String                          | Optional path to the Certificate Authority's certificate that signed the MQTT Broker's certificate. Default is `./certs/ca.crt`.                                                                     |
-| `TLSinsecure` |          | Boolean                         | Optional parameter to configure verification of the server hostname in the server certificate. Default is `False`.                                                                                   |
+| `TLSinsecure` |          | Boolean                         | Optional parameter to disable verification of the server hostname in the server certificate. Default is `False`.                                                                                   |
 
 There are two hard coded topics the Connection will use:
 
@@ -50,7 +50,7 @@ The MQTT connection uses following parameters:
 |--------------|-------------------|--------------|-------------------------------------------------------------------------------------------------------------------|
 | `CommandSrc` | yes for actuators |              | Specifies the topic to subscribe for actuator events                                                              |
 | `StateDest`  |                   |              | Return topic to publish the current device state / sensor readings. If not present the state won't get published. |
-| `Retain`     |                   | boolean      | If True, MQTT will publish messages with the retain flag. Default is False.                                       |
+| `Retain`     |                   | Boolean      | If True, MQTT will publish messages with the retain flag. Default is False.                                       |
 
 #### Dictionary of connectors layout
 To configure a MQTT connection in a sensor / actuator use following layout:
@@ -88,21 +88,22 @@ Can be defined within the `ConnectionOnDisconnect:` and `ConnectionOnReconnect:`
 
 | Parameter         | Required            | Restrictions               | Purpose                                                                                                                                           |
 |-------------------|---------------------|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ChangeState`     |                     | boolean                    | Trigger actuator state change on disconnect/reconnect (default = no)                                                                              |
-| `TargetState`     | if ChangeState: yes | string in single 'quotes'  | The command to send to the actuator when the trigger occurs. Make sure the data type matches the actuator and use single 'quotes'                 |
-| `ResumeLastState` |                     | boolean, only on reconnect | If yes, the actuator will return to the last known state state on reconnection. Only works on actuators with return topic feature (default = no)  |
+| `ChangeState`     |                     | Boolean                    | Trigger actuator state change on disconnect/reconnect (default = no)                                                                              |
+| `TargetState`     | if ChangeState: yes | String in single 'quotes'  | The command to send to the actuator when the trigger occurs. Make sure the data type matches the actuator and use single 'quotes'                 |
+| `ResumeLastState` |                     | Boolean, only on reconnect | If yes, the actuator will return to the last known state state on reconnection. Only works on actuators with return topic feature (default = no)  |
 
 ```yaml
 Connections:
     <connection_name>:
         # actuator topic config omitted
-    	ConnectionOnDisconnect:
-    		ChangeState: < yes / no >
-    		TargetState: 'ON' 			# some value the actuator supports, could be also '0,0,100' for a  PWM dimmer
-    	ConnectionOnReconnect:
-    		ChangeState: < yes / no >
-    		TargetState: 'OFF'
-    		ResumeLastState: < yes / no >
+        ConnectionOnDisconnect:
+            ChangeState: < yes / no >
+            # some value the actuator supports, could be also '0,0,100' for a  PWM dimmer
+            TargetState: 'ON'
+        ConnectionOnReconnect:
+            ChangeState: < yes / no >
+            TargetState: 'OFF'
+            ResumeLastState: < yes / no >
 ```
 
 ##### Sensor related Parameters
@@ -110,7 +111,7 @@ Can be defined within the `ConnectionOnDisconnect:` parameter.
 
 | Parameter          | Required | Restrictions | Purpose                                                                                                               |
 |--------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------        |
-| `SendReadings`     |          | boolean      | If yes, sensors readings will be collected while connection is offline and send when reconnected (default = no)       |
+| `SendReadings`     |          | Boolean      | If yes, sensors readings will be collected while connection is offline and send when reconnected (default = no)       |
 | `NumberOfReadings` |          | Integer      | Number of readings to be collected. Will be sent in the same order after reconnection, oldest first (default = 1 )    |
 
 ```yaml
@@ -216,9 +217,9 @@ Can be defined within the `ConnectionOnDisconnect:` and `ConnectionOnReconnect:`
 
 | Parameter         | Required            | Restrictions               | Purpose                                                                                                                                           |
 |-------------------|---------------------|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ChangeState`     |                     | boolean                    | Trigger actuator state change on disconnect/reconnect (default = no)                                                                              |
-| `TargetState`     | if ChangeState: yes | string in single 'quotes'  | The command to send to the actuator when the trigger occurs. Make sure the data type matches the actuator and use single 'quotes'                 |
-| `ResumeLastState` |                     | boolean, only on reconnect | If yes, the actuator will return to the last known state state on reconnection. Only works on actuators with return topic feature (default = no)  |
+| `ChangeState`     |                     | Boolean                    | Trigger actuator state change on disconnect/reconnect (default = no)                                                                              |
+| `TargetState`     | if ChangeState: yes | String in single 'quotes'  | The command to send to the actuator when the trigger occurs. Make sure the data type matches the actuator and use single 'quotes'                 |
+| `ResumeLastState` |                     | Boolean, only on reconnect | If yes, the actuator will return to the last known state state on reconnection. Only works on actuators with return topic feature (default = no)  |
 
 ```yaml
 Connections:
@@ -239,7 +240,7 @@ Can be defined within the `ConnectionOnDisconnect:` parameter.
 
 | Parameter          | Required | Restrictions | Purpose                                                                                                               |
 |--------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------        |
-| `SendReadings`     |          | boolean      | If yes, sensors readings will be collected while connection is offline and send when reconnected (default = no)       |
+| `SendReadings`     |          | Boolean      | If yes, sensors readings will be collected while connection is offline and send when reconnected (default = no)       |
 | `NumberOfReadings` |          | Integer      | Number of readings to be collected. Will be sent in the same order after reconnection, oldest first (default = 1 )    |
 
 ```yaml

--- a/mqtt/README.md
+++ b/mqtt/README.md
@@ -116,10 +116,10 @@ Can be defined within the `ConnectionOnDisconnect:` parameter.
 ```yaml
 Connections:
     <connection_name>:
-    	# sensor topic config omitted
-    	ConnectionOnDisconnect:
-    		SendReadings: < yes / no >
-    		NumberOfReadings: < whole number >
+        # sensor topic config omitted
+        ConnectionOnDisconnect:
+            SendReadings: < yes / no >
+            NumberOfReadings: < whole number >
 ```
 
 ### Example Config
@@ -224,13 +224,14 @@ Can be defined within the `ConnectionOnDisconnect:` and `ConnectionOnReconnect:`
 Connections:
     <connection_name>:
         # actuator topic config omitted
-    	ConnectionOnDisconnect:
-    		ChangeState: < yes / no >
-    		TargetState: 'ON' 			# some value the actuator supports, could be also '0,0,100' for a  PWM dimmer
-    	ConnectionOnReconnect:
-    		ChangeState: < yes / no >
-    		TargetState: 'OFF'
-    		ResumeLastState: < yes / no >
+        ConnectionOnDisconnect:
+            ChangeState: < yes / no >
+            # some value the actuator supports, could be also '0,0,100' for a  PWM dimmer
+            TargetState: 'ON'
+        ConnectionOnReconnect:
+            ChangeState: < yes / no >
+            TargetState: 'OFF'
+            ResumeLastState: < yes / no >
 ```
 
 ##### Sensor related Parameters
@@ -244,10 +245,10 @@ Can be defined within the `ConnectionOnDisconnect:` parameter.
 ```yaml
 Connections:
     <connection_name>:
-    	# sensor topic config omitted
-    	ConnectionOnDisconnect:
-    		SendReadings: < yes / no >
-    		NumberOfReadings: < whole number >
+        # sensor topic config omitted
+        ConnectionOnDisconnect:
+            SendReadings: < yes / no >
+            NumberOfReadings: < whole number >
 ```
 
 ### Example Config

--- a/mqtt/README.md
+++ b/mqtt/README.md
@@ -107,7 +107,7 @@ Connections:
 ```
 
 ##### Sensor related Parameters
-Can be defined within the `ConnectionOnDisconnect:` parameter.
+Can be defined within the `ConnectionOnReconnect:` parameter.
 
 | Parameter          | Required | Restrictions | Purpose                                                                                                               |
 |--------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------        |
@@ -118,7 +118,7 @@ Can be defined within the `ConnectionOnDisconnect:` parameter.
 Connections:
     <connection_name>:
         # sensor topic config omitted
-        ConnectionOnDisconnect:
+        ConnectionOnReconnect:
             SendReadings: < yes / no >
             NumberOfReadings: < whole number >
 ```
@@ -236,7 +236,7 @@ Connections:
 ```
 
 ##### Sensor related Parameters
-Can be defined within the `ConnectionOnDisconnect:` parameter.
+Can be defined within the `ConnectionOnReconnect:` parameter.
 
 | Parameter          | Required | Restrictions | Purpose                                                                                                               |
 |--------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------        |
@@ -247,7 +247,7 @@ Can be defined within the `ConnectionOnDisconnect:` parameter.
 Connections:
     <connection_name>:
         # sensor topic config omitted
-        ConnectionOnDisconnect:
+        ConnectionOnReconnect:
             SendReadings: < yes / no >
             NumberOfReadings: < whole number >
 ```

--- a/mqtt/homie_conn.py
+++ b/mqtt/homie_conn.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 """Contains the homie connection class.
 
 Classes: HomieConnection
 """
+from typing import Callable, Optional, Any, cast
 from homie_spec import Node, Property, Device
 from homie_spec.properties import Datatype
+import paho.mqtt.client as mqtt
 from mqtt.mqtt_conn import MqttConnection, REFRESH
-from core.utils import ChanType, ChanConst, OUT, IN 
+from core.utils import ChanType, ChanConst, OUT, IN
 
 OUT_STATE = "state"
 IN_CMD_SET = "set"
@@ -27,7 +30,7 @@ IN_CMD = "cmd"
 PARA_CMD_SRC = "CommandSrc"
 
 class HomieConnection(MqttConnection):
-    """Connects to and enables subscription and publishing to MQTT via Homie convention.
+    """ Connects to and enables subscription and publishing to MQTT via Homie convention.
 
     Developer note: Each sensor and actuator (device) must register its inputs and outputs,
     otherwise it can not be used with the HomieConnection.
@@ -41,9 +44,11 @@ class HomieConnection(MqttConnection):
     self._register(self.comm, None)
      """
 
-    def __init__(self, msg_processor, conn_cfg):
-        """Establishes the MQTT connection and starts the MQTT thread.
-        will anounce the registerd devices to the homie standart
+    def __init__(self,
+                 msg_processor:Callable[[str], None],
+                 conn_cfg:dict[str, Any]) -> None:
+        """ Establishes the MQTT connection and starts the MQTT thread.
+            will announce the registered devices to the homie standard
         """
         self.device_id = conn_cfg["DeviceID"].lower()
         self.name = self.device_id + "-sensor_reporter"
@@ -64,7 +69,7 @@ class HomieConnection(MqttConnection):
         super().__init__(msg_processor, conn_cfg)
 
         #get all topic of this device known by the mqtt server
-        self.topics_to_delete = []
+        self.topics_to_delete:list[str] = []
         device_topic = f"{self.root_topic}/#"
         self.client.subscribe(device_topic, qos=0)
         self.client.message_callback_add(device_topic, self.collect_existing_topics)
@@ -78,14 +83,17 @@ class HomieConnection(MqttConnection):
                 typeOf="conn",
                 properties={
                     'status' : Property(name="connection status", datatype=Datatype.STRING,
-                                   get=None),
+                                   get=dummy_getter),
                     REFRESH : Property(name="refresh sensor readings", datatype=Datatype.STRING,
-                                       settable=True, get=None)
+                                       settable=True, get=dummy_getter)
                     })
         self.device.nodes["conn"] = conn_prop
 
-    def publish(self, message, comm_conn, output_name=None):
-        """Publishes message to destination, logging if there is an error.
+    def publish(self,
+                message:str,
+                comm_conn:dict[str, Any],
+                output_name:Optional[str] = None) -> None:
+        """ Publishes message to destination, logging if there is an error.
 
         Arguments:
         - message:     the message to process / publish
@@ -116,10 +124,12 @@ class HomieConnection(MqttConnection):
             destination = comm_conn['Name'] + "/" + OUT_STATE
             self._publish_mqtt(message, destination.lower(), retain)
 
-    def register(self, comm_conn, handler):
-        """Registers actuators and sensorswith the connection.
-        Actuators have to provide a handler to be called on messages received.
-        If no handler is provided the registration of a sensor is assumed.
+    def register(self,
+                 comm_conn:dict[str, Any],
+                 handler:Optional[Callable[[str], None]]) -> None:
+        """ Registers actuators and sensors with the connection.
+            Actuators have to provide a handler to be called on messages received.
+            If no handler is provided the registration of a sensor is assumed.
 
         homie expects following device config:
         Connections:
@@ -146,24 +156,34 @@ class HomieConnection(MqttConnection):
         super().register(comm_conn, handler)
 
         #search for device properties:
-        props = {}
+        props:dict[str, Property] = {}
         if IN in comm_conn:
-            self.register_properties(props, comm_conn[IN], IN_CMD, n_name)
+            props[IN_CMD] = self.get_property(comm_conn[IN], IN_CMD, n_name)
         if OUT in comm_conn:
-            self.register_properties(props, comm_conn[OUT], OUT_STATE, n_name)
+            props[OUT_STATE] = self.get_property(comm_conn[OUT], OUT_STATE, n_name)
 
         if IN not in comm_conn and OUT not in comm_conn:
             for (output, local_comm) in comm_conn.items():
                 if isinstance(local_comm, dict):
-                    self.register_properties(props, local_comm[OUT], output, n_name)
+                    props[output] = self.get_property(local_comm[OUT], output, n_name)
 
         self.device.nodes[n_name] = Node(name=n_name,
-                                                 typeOf=comm_conn.get('Type',''),
-                                                 properties= props)
+                                        typeOf=comm_conn.get('Type',''),
+                                        properties= props)
 
     @staticmethod
-    def register_properties(props:dict, comm_props:dict, channel:str, node_name:str):
-        """will grap all homie relevant properties from the comm dict
+    def get_property(comm_props:dict[str, Any],
+                     channel:str,
+                     node_name:str) -> Property:
+        """ Create homie property from parameters
+            Reads the input/output properties from comm_props
+            and creates a 'Property' with channel name and device name
+            Parameters:
+                - comm_props     : the sub-dictionary from connections
+                                   created by utils.configure_device_channel
+                - channel        : The name of the channel (e. g. Temperature)
+                - node_name      : The name of the sensor/actuator
+            Returns homie Property containing given settings
         """
         homie_types = {
             ChanType.STRING : Datatype.STRING,
@@ -175,36 +195,42 @@ class HomieConnection(MqttConnection):
             }
         channel = channel.lower()
 
-        p_type = homie_types.get(comm_props.get(ChanConst.DATATYPE), Datatype.STRING)
+        # We know 'comm_props.get(ChanConst.DATATYPE)' will return a ChanType
+        # to satisfy the Python type checker we 'cast' the data type
+        p_type = homie_types.get(cast(ChanType, comm_props.get(ChanConst.DATATYPE)),
+                                 Datatype.STRING)
         p_name = comm_props.get(ChanConst.NAME, channel)
         p_unit = comm_props.get(ChanConst.UNIT)
         p_retained = comm_props.get('Retain')
         p_settable = comm_props.get(ChanConst.SETTABLE)
         p_format = comm_props.get(ChanConst.FORMAT)
 
-        props[channel] = Property(name=node_name + ' / ' + p_name, datatype=p_type,
-                                 settable = p_settable, get=None,
-                                 unit = p_unit, retained=p_retained, formatOf=p_format)
+        return Property(name=node_name + ' / ' + p_name, datatype=p_type,
+                        settable = p_settable, get=dummy_getter,
+                        unit = p_unit, retained=p_retained, formatOf=p_format)
 
     #pylint: disable=unused-argument
-    def collect_existing_topics(self, client, userdata, msg):
-        """read out existing topics for this connection and
-        collect them in a list
+    def collect_existing_topics(self,
+                                client:mqtt.Client,
+                                userdata:Any,
+                                msg:mqtt.MQTTMessage) -> None:
+        """ read out existing topics for this connection and
+            collect them in a list
         """
         if msg.retain and msg.topic not in self.topics_to_delete:
             self.topics_to_delete.append(msg.topic)
             #self.log.debug(f"collected topic: {msg.topic}")
     #pylint: enable=unused-argument
 
-    def publish_device_properties(self):
-        """Method is intended for connections with auto discover of sensors
-        and actuators. Such a connection can place the necessary code for auto
-        discover inside this method. It is called after all connections, sensors
-        and actuators are created and running.
+    def publish_device_properties(self) -> None:
+        """ Method is intended for connections with auto discover of sensors
+            and actuators. Such a connection can place the necessary code for auto
+            discover inside this method. It is called after all connections, sensors
+            and actuators are created and running.
         """
         state_topic = "$state"
         prop_topic = "$properties"
-        #remove and unsubscribe from device messages, was only used to get exisitng topics
+        #remove and unsubscribe from device messages, was only used to get existing topics
         device_topic = f"{self.root_topic}/#"
         self.client.message_callback_remove(device_topic)
         self.client.unsubscribe(device_topic)
@@ -220,7 +246,7 @@ class HomieConnection(MqttConnection):
                     if property_path in self.topics_to_delete:
                         self.topics_to_delete.remove(property_path)
 
-            #omit $state = ready message so unsuded topics can get deleted
+            #omit $state = ready message so unused topics can get deleted
             if not (msg.topic.endswith(state_topic) and msg.payload == 'ready'):
                 #remove root topic since publish_mqtt will add it again
                 self._publish_mqtt(msg.payload,
@@ -235,12 +261,22 @@ class HomieConnection(MqttConnection):
 
         self._publish_mqtt('ready', state_topic, True)
 
-        node_keys = ", ".join(self.device.nodes.keys())
+        node_keys = ""
+        # 'self.device.nodes' could be None
+        if isinstance(self.device.nodes, dict):
+            node_keys = ", ".join(self.device.nodes.keys())
         self.log.info("Made following devices available for homie auto discover: %s", node_keys)
 
-    def disconnect(self):
-        """publish homie connection state &
-        close the connection to the MQTT broker.
+    def disconnect(self) -> None:
+        """ publish homie connection state &
+            close the connection to the MQTT broker.
         """
         self._publish_mqtt('disconnected', '$state', True)
         super().disconnect()
+
+def dummy_getter() -> str:
+    """ We don't need a getter for some properties,
+        but the homie spec expects one in any case.
+        So we return an empty string.
+    """
+    return 'dummy_getter'

--- a/mqtt/homie_conn.py
+++ b/mqtt/homie_conn.py
@@ -17,7 +17,7 @@
 
 Classes: HomieConnection
 """
-from typing import Callable, Optional, Any, cast
+from typing import Callable, Optional, Any, Dict, List, cast
 from homie_spec import Node, Property, Device
 from homie_spec.properties import Datatype
 import paho.mqtt.client as mqtt
@@ -46,7 +46,7 @@ class HomieConnection(MqttConnection):
 
     def __init__(self,
                  msg_processor:Callable[[str], None],
-                 conn_cfg:dict[str, Any]) -> None:
+                 conn_cfg:Dict[str, Any]) -> None:
         """ Establishes the MQTT connection and starts the MQTT thread.
             will announce the registered devices to the homie standard
         """
@@ -69,7 +69,7 @@ class HomieConnection(MqttConnection):
         super().__init__(msg_processor, conn_cfg)
 
         #get all topic of this device known by the mqtt server
-        self.topics_to_delete:list[str] = []
+        self.topics_to_delete:List[str] = []
         device_topic = f"{self.root_topic}/#"
         self.client.subscribe(device_topic, qos=0)
         self.client.message_callback_add(device_topic, self.collect_existing_topics)
@@ -91,7 +91,7 @@ class HomieConnection(MqttConnection):
 
     def publish(self,
                 message:str,
-                comm_conn:dict[str, Any],
+                comm_conn:Dict[str, Any],
                 output_name:Optional[str] = None) -> None:
         """ Publishes message to destination, logging if there is an error.
 
@@ -125,7 +125,7 @@ class HomieConnection(MqttConnection):
             self._publish_mqtt(message, destination.lower(), retain)
 
     def register(self,
-                 comm_conn:dict[str, Any],
+                 comm_conn:Dict[str, Any],
                  handler:Optional[Callable[[str], None]]) -> None:
         """ Registers actuators and sensors with the connection.
             Actuators have to provide a handler to be called on messages received.
@@ -156,7 +156,7 @@ class HomieConnection(MqttConnection):
         super().register(comm_conn, handler)
 
         #search for device properties:
-        props:dict[str, Property] = {}
+        props:Dict[str, Property] = {}
         if IN in comm_conn:
             props[IN_CMD] = self.get_property(comm_conn[IN], IN_CMD, n_name)
         if OUT in comm_conn:
@@ -172,7 +172,7 @@ class HomieConnection(MqttConnection):
                                         properties= props)
 
     @staticmethod
-    def get_property(comm_props:dict[str, Any],
+    def get_property(comm_props:Dict[str, Any],
                      channel:str,
                      node_name:str) -> Property:
         """ Create homie property from parameters

--- a/mqtt/mqtt_conn.py
+++ b/mqtt/mqtt_conn.py
@@ -19,7 +19,7 @@ Classes: MqttConnection
 import socket
 import traceback
 from time import sleep
-from typing import Callable, Optional, Any, Tuple
+from typing import Callable, Optional, Any, Tuple, Dict
 import paho.mqtt.client as mqtt
 from core.connection import Connection
 
@@ -32,7 +32,7 @@ class MqttConnection(Connection):
 
     def __init__(self,
                  msg_processor:Callable[[str], None],
-                 conn_cfg:dict[str, Any]) -> None:
+                 conn_cfg:Dict[str, Any]) -> None:
         """ Establishes the MQTT connection and starts the MQTT thread.
             Expects the following parameters in params:
             - "Host": hostname or IP address of the MQTT broker
@@ -132,7 +132,7 @@ class MqttConnection(Connection):
 
     def publish(self,
                 message:str,
-                comm_conn:dict[str, Any],
+                comm_conn:Dict[str, Any],
                 output_name:Optional[str] = None) -> None:
         """ Publishes message to destination, logging if there is an error.
 
@@ -193,7 +193,7 @@ class MqttConnection(Connection):
         self.client.disconnect()
 
     def register(self,
-                 comm_conn:dict[str, Any],
+                 comm_conn:Dict[str, Any],
                  handler:Optional[Callable[[str], None]]) -> None:
         """ Registers a handler to be called on messages received on topic
             appended to the root_topic. Handler is expected to take one argument,
@@ -228,7 +228,7 @@ class MqttConnection(Connection):
     def on_connect(self,
                    client:mqtt.Client,
                    userdata:Any,
-                   flags:dict[str, int],
+                   flags:Dict[str, int],
                    retcode:int) -> None:
         """ Called when the client connects to the broker, resubscribe to the
             sensorReporter topic.

--- a/mqtt/mqtt_conn.py
+++ b/mqtt/mqtt_conn.py
@@ -19,6 +19,7 @@ Classes: MqttConnection
 import socket
 import traceback
 from time import sleep
+from typing import Callable, Optional, Any, Tuple
 import paho.mqtt.client as mqtt
 from core.connection import Connection
 
@@ -27,25 +28,27 @@ ONLINE = "ONLINE"
 OFFLINE = "OFFLINE"
 
 class MqttConnection(Connection):
-    """Connects to and enables subscription and publishing to MQTT."""
+    """ Connects to and enables subscription and publishing to MQTT."""
 
-    def __init__(self, msg_processor, conn_cfg):
-        """Establishes the MQTT connection and starts the MQTT thread. Exepcts
-        the following parameters in params:
-        - "Host": hostname or IP address of the MQTT broker
-        - "Port": port for the MQTT broker
-        - "Client": client ID to register with the MQTT broker, must be unique
-        - "RootTopic": root topic that will be the vase of the topic hierarchy
-        this connection subscribes and publishes to.
-        - "TLS": optional parameters to determine if the connection should be
-        encrypted using TLS.
-        - "CAcert": Optional path to the CA cert file.
-        If not set, default is ./certs/ca.crt
-        - "TLSinsecure": Optional parameter to disable check of hostname in the
-        certificate. Default is False.
-        - "User": MQTT broker login user name
-        - "Password": MQTT broker login password
-        - "Keepalive": MQTT keepalive parameter
+    def __init__(self,
+                 msg_processor:Callable[[str], None],
+                 conn_cfg:dict[str, Any]) -> None:
+        """ Establishes the MQTT connection and starts the MQTT thread.
+            Expects the following parameters in params:
+            - "Host": hostname or IP address of the MQTT broker
+            - "Port": port for the MQTT broker
+            - "Client": client ID to register with the MQTT broker, must be unique
+            - "RootTopic": root topic that will be the vase of the topic hierarchy
+                        this connection subscribes and publishes to.
+            - "TLS": optional parameters to determine if the connection should be
+                    encrypted using TLS.
+            - "CAcert": Optional path to the CA cert file.
+                        If not set, default is ./certs/ca.crt
+            - "TLSinsecure": Optional parameter to disable check of hostname in the
+                            certificate. Default is False.
+            - "User": MQTT broker login user name
+            - "Password": MQTT broker login password
+            - "Keepalive": MQTT keepalive parameter
 
         If the connection fails, it will keep retrying every five seconds until
         the connection is successful.
@@ -111,7 +114,7 @@ class MqttConnection(Connection):
         # ONLINE state for lwtt and the base class will be set
         # after fully connected in on_connect()
 
-    def _connect(self):
+    def _connect(self) -> None:
         while not self.connected:
             try:
                 self.client.connect(self.host, port=self.port,
@@ -127,8 +130,11 @@ class MqttConnection(Connection):
         self.log.info("Connection to MQTT is successful")
         super().conn_is_connecting()
 
-    def publish(self, message, comm_conn, output_name=None):
-        """Publishes message to destination, logging if there is an error.
+    def publish(self,
+                message:str,
+                comm_conn:dict[str, Any],
+                output_name:Optional[str] = None) -> None:
+        """ Publishes message to destination, logging if there is an error.
 
         Arguments:
         - message:     the message to process / publish
@@ -154,7 +160,10 @@ class MqttConnection(Connection):
 
         self._publish_mqtt(message, destination, retain)
 
-    def _publish_mqtt(self, message, topic, retain):
+    def _publish_mqtt(self,
+                      message:str,
+                      topic:str,
+                      retain:bool) -> None:
         try:
             if not self.connected:
                 self.log.warning(
@@ -163,7 +172,7 @@ class MqttConnection(Connection):
                 return
             full_topic = "{}/{}".format(self.root_topic, topic)
             rval = self.client.publish(
-                full_topic, message, retain=retain, qos=0)
+                        full_topic, message, retain=retain, qos=0)
             if rval[0] == mqtt.MQTT_ERR_NO_CONN:
                 self.log.error(
                     "Error puiblishing update %s to %s", message, full_topic)
@@ -176,17 +185,19 @@ class MqttConnection(Connection):
                 "Unexpected error publishing MQTT message: %s", traceback.format_exc()
             )
 
-    def disconnect(self):
-        """Closes the connection to the MQTT broker."""
+    def disconnect(self) -> None:
+        """ Closes the connection to the MQTT broker."""
         self.log.info("Disconnecting from MQTT")
         self._publish_mqtt(OFFLINE, self.lwt, True)
         self.client.loop_stop()
         self.client.disconnect()
 
-    def register(self, comm_conn, handler):
-        """Registers a handler to be called on messages received on topic
-        appended to the root_topic. Handler is expected to take one argument,
-        the message.
+    def register(self,
+                 comm_conn:dict[str, Any],
+                 handler:Optional[Callable[[str], None]]) -> None:
+        """ Registers a handler to be called on messages received on topic
+            appended to the root_topic. Handler is expected to take one argument,
+            the message.
         """
         #handler can be None if a sensor registers it's outputs
         if handler:
@@ -194,7 +205,9 @@ class MqttConnection(Connection):
             full_topic = "{}/{}".format(self.root_topic, destination)
             self.log.info("Registering for messages on '%s'", full_topic)
 
-            def on_message(client, userdata, msg):
+            def on_message(client:mqtt.Client,
+                           userdata:Any,
+                           msg:mqtt.MQTTMessage) -> None:
                 message = msg.payload.decode("utf-8")
 
                 self.log.debug(
@@ -205,11 +218,18 @@ class MqttConnection(Connection):
                 )
                 handler(message)
 
-            self.registered[full_topic] = on_message
+            # We use self.registered here only to store the topic to re-subscribe later.
+            # The handler in .register is not used,
+            # we only set it to satisfy the Python type checker
+            self.registered[full_topic] = handler
             self.client.subscribe(full_topic, qos=0)
             self.client.message_callback_add(full_topic, on_message)
 
-    def on_connect(self, client, userdata, flags, retcode):
+    def on_connect(self,
+                   client:mqtt.Client,
+                   userdata:Any,
+                   flags:dict[str, int],
+                   retcode:int) -> None:
         """ Called when the client connects to the broker, resubscribe to the
             sensorReporter topic.
             Gets automatically called from self.client after connection
@@ -241,9 +261,12 @@ class MqttConnection(Connection):
         # causes sensors to republish their states
         self.msg_processor("MQTT connected")
 
-    def on_disconnect(self, client, userdata, retcode):
-        """Called when the client disconnects from the broker. If the reason was
-        not because disconnect() was called, try to reconnect.
+    def on_disconnect(self,
+                      client:mqtt.Client,
+                      userdata:Any,
+                      retcode:int) -> None:
+        """ Called when the client disconnects from the broker. If the reason was
+            not because disconnect() was called, try to reconnect.
         """
         self.log.info(
             "Disconnected from MQTT broker with client %s, userdata " "%s, and code %s",
@@ -262,8 +285,11 @@ class MqttConnection(Connection):
             )
             self._connect()
 
-    def on_publish(self, client, userdata, retcode):
-        """Called when a message is published. """
+    def on_publish(self,
+                   client:mqtt.Client,
+                   userdata:Any,
+                   retcode:int) -> None:
+        """ Called when a message is published. """
         self.log.debug(
             "on_publish: Successfully published message %s, %s, %s",
             client,
@@ -271,8 +297,12 @@ class MqttConnection(Connection):
             retcode,
         )
 
-    def on_subscribe(self, client, userdata, retcode, qos):
-        """Called when a topic is subscribed to. """
+    def on_subscribe(self,
+                     client:mqtt.Client,
+                     userdata:Any,
+                     retcode:int,
+                     qos:Tuple[int]) -> None:
+        """ Called when a topic is subscribed to. """
         self.log.debug(
             "on_subscribe: Successfully subscribed %s, %s, %s, %s",
             client,

--- a/openhab_rest/README.md
+++ b/openhab_rest/README.md
@@ -149,7 +149,7 @@ By default the openHAB server has created a certificate which is unknown to sens
 To connect anyway use `TLSinsecure: yes`.
 This will skip the certificate validation, i.e. sensor_reporter will not recognize if the server changes and a man in the middle attack would be possible.
 
-To enable certificate validation self signed certificates must be created and installed in openHAB and sensor_reporter. 
+To enable certificate validation, self-signed certificates must be created and installed in openHAB and sensor_reporter:
 1. Create certificates: [this](https://blog.devgenius.io/how-to-generate-self-signed-ssl-certificates-b85562830ab) webside explains this for Linux and Mac
 2. Install the server certificate in openHAB following this [guide](https://gist.github.com/DanielDecker/5ab62a55fd9e53d0bfd3d7ffec1a4916)
 3. Configure the path to the root certificate in openHAB with `CAcert:`

--- a/openhab_rest/README.md
+++ b/openhab_rest/README.md
@@ -90,7 +90,7 @@ Connections:
 ```
 
 ##### Sensor related Parameters
-Can be defined within the `ConnectionOnDisconnect:` parameter.
+Can be defined within the `ConnectionOnReconnect:` parameter.
 
 | Parameter          | Required | Restrictions | Purpose                                                                                                               |
 |--------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------        |
@@ -101,7 +101,7 @@ Can be defined within the `ConnectionOnDisconnect:` parameter.
 Connections:
     <connection_name>:
         # sensor topic config omitted
-        ConnectionOnDisconnect:
+        ConnectionOnReconnect:
             SendReadings: < yes / no >
             NumberOfReadings: < whole number >
 ```

--- a/openhab_rest/README.md
+++ b/openhab_rest/README.md
@@ -2,11 +2,12 @@
 
 This Connection provides a two way connection to an openHAB instance.
 I uses the REST API to publish Item updates and it subscribes to the SSE feed for Item commands.
+Checks connection status every 30 seconds.
+Automatically reconnects if necessary.
 
 ## Dependencies
 
-Uses [requests](https://pypi.org/project/requests/) to issue the Item updates.
-
+Item updates are issue via [requests](https://pypi.org/project/requests/).
 Uses [sseclient-py](https://pypi.org/project/sseclient-py/) to subscribe to the SSE feed.
 
 ```bash
@@ -21,10 +22,13 @@ sudo ./install_dependencies.sh openhab_rest
 | `Class`           | X        | `openhab_rest.rest_conn.OpenhabREST` |                                                                                                                                                                                                                                                                                                 |
 | `Level`           |          | DEBUG, INFO, WARNING, ERROR          | When provided, sets the logging level for the connection.                                                                                                                                                                                                                                       |
 | `Name`            | X        | Unique to sensor_reporter            | Name for the connection, used in the list of Connections for Actuators and Sensors.                                                                                                                                                                                                             |
-| `URL`             | X        | http URL                             | The base URL and port of the openHAB instance.                                                                                                                                                                                                                                                  |
+| `URL`             | X        | http / https URL : port              | The base URL and port of the openHAB instance. Example unencrypted: `http://localhost:8080`, example with TLS encryption: `https://localhost:8443`. For the later a Certificate Authority's certificate must be set.                                                                            |
 | `RefreshItem`     | X        |                                      | Name of a Switch Item; sending an ON command to the Item will cause sensor_reporter to publish the most recent state of all the sensors.                                                                                                                                                        |
-| `openHAB-Version` |          | float                                | Version of the OpenHAB server to connect to as floating point figure. Default is '2.0'.                                                                                                                                                                                                         |
+| `openHAB-Version` |          | Float                                | Version of the OpenHAB server to connect to as floating point figure. Default is '2.0'.                                                                                                                                                                                                         |
 | `API-Token`       |          |                                      | The API token generated on the [web interface](https://www.openhab.org/docs/configuration/apitokens.html). Only needed if 'settings > API-security > implicit user role (advanced settings)' is disabled. If no API token is specified sensor_reporter tries to connect without authentication. |
+| `CAcert`          |          | String                               | Optional path to the Certificate Authority's certificate that signed the openHab certificate. Example: `./certs/ca.crt` Default is no certificate.                                                                                                                                              |
+| `TLSinsecure`     |          | Boolean                              | Optional parameter to disable verification of the server hostname in the server certificate. Default is `False`.                                                                                                                                                                               |
+
 
 ### Actuator / sensor relevant parameters
 
@@ -58,6 +62,50 @@ Connections:
         Item: <some Item_name>
 ```
 
+#### Trigger disconnect / reconnect actions
+This connection supports triggering actions on disconnect / reconnect for actuators and storing sensor readings while the connection is offline and sending them all at once on reconnect for sensors.
+These options are configured for each device and are defined within the device's `Connections:` parameter. 
+
+##### Actuator related parameters:
+Can be defined within the `ConnectionOnDisconnect:` and `ConnectionOnReconnect:` parameter.
+
+| Parameter         | Required            | Restrictions               | Purpose                                                                                                                                           |
+|-------------------|---------------------|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ChangeState`     |                     | Boolean                    | Trigger actuator state change on disconnect/reconnect (default = no)                                                                              |
+| `TargetState`     | if ChangeState: yes | String in single 'quotes'  | The command to send to the actuator when the trigger occurs. Make sure the data type matches the actuator and use single 'quotes'                 |
+| `ResumeLastState` |                     | Boolean, only on reconnect | If yes, the actuator will return to the last known state state on reconnection. Only works on actuators with return topic feature (default = no)  |
+
+```yaml
+Connections:
+    <connection_name>:
+        # actuator topic config omitted
+        ConnectionOnDisconnect:
+            ChangeState: < yes / no >
+            # some value the actuator supports, could be also '0,0,100' for a  PWM dimmer
+            TargetState: 'ON'
+        ConnectionOnReconnect:
+            ChangeState: < yes / no >
+            TargetState: 'OFF'
+            ResumeLastState: < yes / no >
+```
+
+##### Sensor related Parameters
+Can be defined within the `ConnectionOnDisconnect:` parameter.
+
+| Parameter          | Required | Restrictions | Purpose                                                                                                               |
+|--------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------        |
+| `SendReadings`     |          | Boolean      | If yes, sensors readings will be collected while connection is offline and send when reconnected (default = no)       |
+| `NumberOfReadings` |          | Integer      | Number of readings to be collected. Will be sent in the same order after reconnection, oldest first (default = 1 )    |
+
+```yaml
+Connections:
+    <connection_name>:
+        # sensor topic config omitted
+        ConnectionOnDisconnect:
+            SendReadings: < yes / no >
+            NumberOfReadings: < whole number >
+```
+
 ## Example Configs
 
 ```yaml
@@ -85,19 +133,24 @@ SensorHeartbeart:
     Poll: 60
 ```
 
-To detect when a sensor_reporter goes offline, use the Heartbeat and a timer in openHAB to detect when the heartbeat stops.
-
-This connection has a passive disconnect detection.
-Whenever a message to openHAB is send the reception of the message is checked.
-If there is no message reception detected eg. after the restart of openHAB, sensor_reporter will automatically reconnect.
-To make full use of this feature a Heartbeat every 60s is recommended.
-
-
-## OpenHAB Setup
+## OpenHAB setup
 Login in openHAB as Admin and add a new point (settings > model > add point) for every sensor/actor to use with sensor_reporter.
 You can add the point straight away to the [semantic model](https://www.openhab.org/docs/tutorial/model.html) of your smart home or do it later.
 Obviously the point names in openHAB and in the sensor_reporter config have to be the identical.
 Point label can be chosen freely.
 The point type vary, see the plugin readme's for more information.
 
-Note: on a setup with an sensor and an actuator with the same label, the actuator will not get triggered thru openHAB when an update on the destination happens. Use a local/mqtt connection for direct sensor actuator connections.
+Note: In a setup with a sensor and an actuator with the same label, the actuator will not be triggered by openHAB when an update on the destination happens.
+Use a local/mqtt connection for direct sensor/actuator connections.
+
+## Connection encryption
+To access the openHAB REST-API with an encrypted connection, configure `URL` with https:// prefix and port 8443.
+By default the openHAB server has created a certificate which is unknown to sensor_reporter.
+To connect anyway use `TLSinsecure: yes`.
+This will skip the certificate validation, i.e. sensor_reporter will not recognize if the server changes and a man in the middle attack would be possible.
+
+To enable certificate validation self signed certificates must be created and installed in openHAB and sensor_reporter. 
+1. Create certificates: [this](https://blog.devgenius.io/how-to-generate-self-signed-ssl-certificates-b85562830ab) webside explains this for Linux and Mac
+2. Install the server certificate in openHAB following this [guide](https://gist.github.com/DanielDecker/5ab62a55fd9e53d0bfd3d7ffec1a4916)
+3. Configure the path to the root certificate in openHAB with `CAcert:`
+4. Start sensor_reporter

--- a/openhab_rest/rest_conn.py
+++ b/openhab_rest/rest_conn.py
@@ -17,7 +17,7 @@
         - openhab_rest: publishes state updates to openHAB Items.
 """
 from threading import Thread, Timer
-from typing import Callable, Optional, Union, Any
+from typing import Callable, Optional, Union, Any, Dict
 import json
 import traceback
 import requests
@@ -32,7 +32,7 @@ class OpenhabREST(Connection):
 
     def __init__(self,
                  msg_processor:Callable[[str], None],
-                 conn_cfg:dict[str, Any]) -> None:
+                 conn_cfg:Dict[str, Any]) -> None:
         """ Starts the SSE subscription and registers for commands on
             RefreshItem. Expects the following params:
             - "URL": base URL of the openHAB instance NOTE: does not support TLS.
@@ -129,7 +129,7 @@ class OpenhabREST(Connection):
 
     def publish(self,
                 message:str,
-                comm_conn:dict[str, Any],
+                comm_conn:Dict[str, Any],
                 output_name:Optional[str] = None) -> None:
         """ Publishes the passed in message to the passed in destination as an update.
 
@@ -199,7 +199,7 @@ class OpenhabREST(Connection):
         self.conn_check.cancel()
 
     def register(self,
-                 comm_conn:dict[str, Any],
+                 comm_conn:Dict[str, Any],
                  handler:Optional[Callable[[str], None]]) -> None:
         """ Set up the passed in handler to be called for any message on the
             destination. Alternate implementation using 'Item' as Topic
@@ -216,7 +216,7 @@ class OpenhabReciever():
 
     def __init__(self,
                  caller:OpenhabREST,
-                 header:Optional[dict[str, str]]) -> None:
+                 header:Optional[Dict[str, str]]) -> None:
         """  Parameter:
             - caller    : The class object from the calling OpenhabREST
             - header    : HTTP header which is send to openHAB when
@@ -234,7 +234,7 @@ class OpenhabReciever():
 
     @staticmethod
     def subscribe_to_events(caller:OpenhabREST,
-                            header:Optional[dict[str, str]]) -> Optional[sseclient.SSEClient]:
+                            header:Optional[Dict[str, str]]) -> Optional[sseclient.SSEClient]:
         """ Subscribe to SSE events and start processing the events
             if API-Token is provided and supported then include it in the request
             Parameter:

--- a/test_type-checker/README.md
+++ b/test_type-checker/README.md
@@ -1,0 +1,40 @@
+# Static type check with mypy
+
+This is only intended for testing the Python code during development.
+A type checker can be used to check the consistency of static data types of Python variables.
+This means that runtime exceptions due to type mismatches can be found without trail and error.
+This file explains how to use `mypy` to perform a type check.
+
+## Dependencies
+The Python module `mypy` is required as the following type definition packages: types-PyYAML, types-paho-mqtt, types-requests, types-pyserial.
+
+```bash
+cd /srv/sensorReporter
+sudo ./install_dependencies.sh test-typeshed
+```
+
+Most checks are disabled by default.
+Three configuration files are provided to define common use cases:
+
+| Filename                | use case                                                                                                                                                                                    |
+|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| mypy-strict.ini         | Prints errors for missing type definitions. Useful for checking individual files and their dependencies. To find out if type annotations are missing.                                       |
+| mypy-ignore-untyped.ini | This configuration will skip untyped methods. Useful when checking multiple files containing typed and untyped methods.                                                                     |
+| mypy-check-untyped.ini  | This will also check untyped methods and assume unknown types as 'Any'. This will result in errors that will never throw a runtime exception. Useful for checking individual untyped files. |
+
+To run the type checker, specify a configuration and the relative path to the file that you want to be checked.
+If the path is omitted, all Python files in the working directory will be checked.
+
+```bash
+cd /srv/sensorReporter
+bin/python -m mypy --config-file <relative-path/to/ini-file> <relative-path/to/python-file>
+bin/python -m mypy --config-file test_type-checker/mypy-strict.ini sensor_reporter.py
+```
+
+To find out the data type out mypy has detected, use the following method.
+It will print the data type of the given variable.
+But note that it will also be parsed by Python at runtime and Python will also print the type.
+
+```python
+reveal_type(<variable>)
+```

--- a/test_type-checker/dependencies.txt
+++ b/test_type-checker/dependencies.txt
@@ -1,0 +1,11 @@
+[pip]
+# the type checker
+mypy
+# required for sensor_reporter.py (load YAML file)
+types-PyYAML
+# required for mqtt/mqtt_conn.py
+types-paho-mqtt
+# required for openhab_rest/rest_conn.py
+types-requests
+# required for energymeter
+types-pyserial

--- a/test_type-checker/mypy-check-untyped.ini
+++ b/test_type-checker/mypy-check-untyped.ini
@@ -1,6 +1,6 @@
 [mypy]
-# make sure python 3.7 is supported
-python_version = 3.7
+# make sure Python 3.8 is supported, current system (Python 3.11) does not offer checking against 3.7
+python_version = 3.8
 # python 3.7 only supports union syntax
 force_union_syntax = True
 show_error_context = True

--- a/test_type-checker/mypy-check-untyped.ini
+++ b/test_type-checker/mypy-check-untyped.ini
@@ -1,0 +1,16 @@
+[mypy]
+# make sure python 3.7 is supported
+python_version = 3.7
+# python 3.7 only supports union syntax
+force_union_syntax = True
+show_error_context = True
+pretty = True
+warn_unreachable = True
+warn_no_return = True
+disallow_any_generics = True
+disallow_untyped_calls = True
+disallow_incomplete_defs = True
+strict_equality = True
+check_untyped_defs = True
+files = sensor_reporter.py,*/*.py
+

--- a/test_type-checker/mypy-ignore-untyped.ini
+++ b/test_type-checker/mypy-ignore-untyped.ini
@@ -1,0 +1,16 @@
+[mypy]
+# make sure python 3.7 is supported
+python_version = 3.7
+# python 3.7 only supports union syntax
+force_union_syntax = True
+show_error_context = True
+pretty = True
+warn_unreachable = True
+warn_no_return = True
+disallow_any_generics = True
+disallow_untyped_calls = True
+disallow_incomplete_defs = True
+strict_equality = True
+# Files to check if no path is given in the cli
+files = sensor_reporter.py,*/*.py
+

--- a/test_type-checker/mypy-ignore-untyped.ini
+++ b/test_type-checker/mypy-ignore-untyped.ini
@@ -1,6 +1,6 @@
 [mypy]
-# make sure python 3.7 is supported
-python_version = 3.7
+# make sure Python 3.8 is supported, current system (Python 3.11) does not offer checking against 3.7
+python_version = 3.8
 # python 3.7 only supports union syntax
 force_union_syntax = True
 show_error_context = True

--- a/test_type-checker/mypy-strict.ini
+++ b/test_type-checker/mypy-strict.ini
@@ -1,6 +1,6 @@
 [mypy]
-# make sure python 3.7 is supported
-python_version = 3.7
+# make sure Python 3.8 is supported, current system (Python 3.11) does not offer checking against 3.7
+python_version = 3.8
 # python 3.7 only supports union syntax
 force_union_syntax = True
 show_error_context = True

--- a/test_type-checker/mypy-strict.ini
+++ b/test_type-checker/mypy-strict.ini
@@ -1,0 +1,18 @@
+[mypy]
+# make sure python 3.7 is supported
+python_version = 3.7
+# python 3.7 only supports union syntax
+force_union_syntax = True
+show_error_context = True
+pretty = True
+warn_unreachable = True
+warn_no_return = True
+
+strict = True
+# Following is included in 'strict'
+#disallow_any_generics = True
+#disallow_untyped_calls = True
+#disallow_incomplete_defs = True
+#strict_equality = True
+# Files to check if no path is given in the cli
+files = sensor_reporter.py,*/*.py


### PR DESCRIPTION
This PR adds the functionality we discussed in issue #104: Sensor readings recorded during an offline phase will be sent when the connector is reconnected (configurable). Actuators can perform defined actions on disconnect/reconnect.

This is implemented in the core classes (connector, sensor, actuator), so a connector can implement this with a simple call to two methods (`super().conn_went_offline()`, `super().conn_went_online()`). I have already implemented this already for the mqtt, homie and openHAB_REST connectors. The latter needed some changes in the logic as it didn't have any code to detect if the connection went offline. I tested all the changes on my little test setup. This consists of a single rPi running server (mqtt, openHAB) and sensor_reporter simultaneously. Obviously testing disconnect/reconnect events is not so easy on this setup. I also want to test this code on a larger setup with multiple rPi and +10 sensors/actuators. In order to give you more time for review, I am opening this PR as a draft now.

Overview:
+added disconnect/reconnect triggers to core classes
+added a checker_connection() method to rest_conn.py
+added parameters and documentation for TLS encrypted connection to openHAB
+added type annotations to modified modules and to sensor_reporter.py
+added documentation how to use type checker
*modified connectors to use `super().conn_went_offline()`, `super().conn_went_online()`


I tested the changes with Python 3.7 and 3.11, with kernel 5.10 and 6.6 and the openHAB connector with OH versions 2.5, 3.3 and 4.1
Will report back here after further testing!