### PR TITLE
add type annotations for i2c actuators

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ This current version is a nearly complete rewrite of the previous version with a
 
 ## Other changes
 
+- Several connectors now support a disconnect/reconnect action for sensors/actuators
 - RpiGpioActuator and GpioColorLED now uses lgpio library
 - RpiGpioSensor now uses lgpio library (fixes edge detection not working on kernel 6.6)
 - Logs out to standard out in addition to Syslog or log files.

--- a/i2c/README.md
+++ b/i2c/README.md
@@ -36,9 +36,7 @@ sudo ./install_dependencies.sh i2c
 | `ToggleDebounce` |          | decimal number                  | The interval in seconds during which repeated toggle commands are ignored (default 0.15 seconds)                                                                                                                                                                              |
 | `InitialState`   |          | ON or OFF                       | Optional, when set to ON the pin's state is initialized to HIGH. Ignores InvertOut (default OFF)                                                                                                                                                                              |
 | `SimulateButton` |          | Boolean                         | When `True` simulates a button press by setting the pin to HIGH for half a second and then back to LOW. In case of `InitalState` ON it will toggle the other way around.                                                                                                      |
-
-
-
+| `InvertOut`      |          | Boolean                         | Inverts the output when set to `True`. If inverted, sending `ON` to the actuator will switch the relay off and `OFF` will switch the relay on (default False).                                                                                                                |
 
 ### Outputs / Inputs
 


### PR DESCRIPTION
This PR adds type annotations for the i2c actuators, solves #128 and adds an InvertOut option for the relay hat.

+added type annotations to enable type checking e.g. with mypy
+added InvertOut option to EightRelayHat to invert the logic (cmd ON turns the relay off)
+added note for disconnect/reconnect actions to change log in the main readme
*modified PwmHatColorLED to use the ColorHSV class defined in utils.py

I tested the changes with the actuators.
This PR is ready for merge.