### PR TITLE
Allow MQTT TLS connection without specifying CA certificate

### DIFF
--- a/mqtt/README.md
+++ b/mqtt/README.md
@@ -33,7 +33,7 @@ sudo ./install_dependencies.sh mqtt
 | `Keepalive`   | X        | Seconds                         | How frequently to exchange keep alive messages with the broker. The smaller the number the faster the broker will detect this client has gone offline but the more network traffic will be consumed. |
 | `RootTopic`   | X        | Valid MQTT topic, no wild cards | Serves as the root topic for all the messages published. For example, if an RpiGpioSensor has a destination "back-door", the actual topic published to will be `<RootTopic>/back-door`.              |
 | `TLS`         |          | Boolean                         | If set to `True`, will use TLS encryption in the connection to the MQTT broker.                                                                                                                      |
-| `CAcert`      |          | String                          | Optional path to the Certificate Authority's certificate that signed the MQTT Broker's certificate. Default is `./certs/ca.crt`.                                                                     |
+| `CAcert`      |          | String                          | Optional path to the Certificate Authority's certificate that signed the MQTT Broker's certificate. Default is `None`.                                                                     |
 | `TLSinsecure` |          | Boolean                         | Optional parameter to disable verification of the server hostname in the server certificate. Default is `False`.                                                                                   |
 
 There are two hard coded topics the Connection will use:

--- a/mqtt/mqtt_conn.py
+++ b/mqtt/mqtt_conn.py
@@ -73,7 +73,7 @@ class MqttConnection(Connection):
 
         #optional parameters
         tls = conn_cfg.get("TLS", False)
-        ca_cert = conn_cfg.get("CAcert", "./certs/ca.crt")
+        ca_cert = conn_cfg.get("CAcert", None)
         tls_insecure = conn_cfg.get("TLSinsecure", False)
 
         user = conn_cfg["User"]
@@ -86,7 +86,10 @@ class MqttConnection(Connection):
         self.client = mqtt.Client(client_id=client_name, clean_session=True)
         if tls:
             self.log.debug("TLS is true, CA cert is: {}".format(ca_cert))
-            self.client.tls_set(ca_cert)
+            if ca_cert:
+                self.client.tls_set(ca_cert)
+            else:
+                self.client.tls_set()
             self.log.debug("TLS insecure is {}".format(tls_insecure))
             self.client.tls_insecure_set(tls_insecure)
         self.client.on_connect = self.on_connect


### PR DESCRIPTION
CA certificate is required only for self-signed certificates.
If the domain is registered only the TLS option is required.

Use case would be MQTT broker behind reverse-proxy with let's encrypt domain certificate. 